### PR TITLE
Add support for Switch class in ECHONET Lite integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ These device classes are enabled by default:
 | 0x0135 | Air Cleaner | Fan + generic entities |
 | 0x0279 | Residential Solar Power Generation | Generic entities |
 | 0x027D | Storage Battery | Generic entities |
+| 0x05FD | Switch (supporting JEM-A/HA terminals) | Generic entities |
 | 0x05FF | Controller | Generic entities |
 
 ### Climate (0x0130) Features

--- a/custom_components/echonet_lite/const.py
+++ b/custom_components/echonet_lite/const.py
@@ -55,6 +55,7 @@ STABLE_CLASS_CODES: frozenset[int] = frozenset(
         0x0135,  # Air cleaner
         0x0279,  # Fuel cell (residential solar power generation)
         0x027D,  # In-house power generation (storage battery)
+        0x05FD,  # Switch (supporting JEM-A/HA terminals)
         0x05FF,  # Controller
     }
 )


### PR DESCRIPTION
Introduce support for the Switch class, enabling integration with JEM-A/HA terminals in the ECHONET Lite framework.