### PR TITLE
entityの属性にEPCを追加する

### DIFF
--- a/custom_components/echonet_lite/const.py
+++ b/custom_components/echonet_lite/const.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
 )
 
 DOMAIN = "echonet_lite"
+ATTR_EPC = "epc"
 CONF_INTERFACE = "interface"
 CONF_ENABLE_EXPERIMENTAL = "enable_experimental"
 DEFAULT_INTERFACE = "0.0.0.0"

--- a/custom_components/echonet_lite/entity.py
+++ b/custom_components/echonet_lite/entity.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DEDICATED_PLATFORM_EPCS, DOMAIN, RUNTIME_MONITOR_MAX_SILENCE
+from .const import ATTR_EPC, DEDICATED_PLATFORM_EPCS, DOMAIN, RUNTIME_MONITOR_MAX_SILENCE
 from .coordinator import EchonetLiteCoordinator
 from .types import EchonetLiteConfigEntry
 
@@ -288,6 +288,11 @@ class EchonetLiteDescribedEntity[DescriptionT: EchonetLiteEntityDescription](
         elif description.fallback_name:
             self._attr_name = description.fallback_name
         self._epc = description.epc
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return extra state attributes exposing the ECHONET Property Code."""
+        return {ATTR_EPC: f"0x{self._epc:02X}"}
 
 
 def setup_echonet_lite_platform[DescriptionT: EchonetLiteEntityDescription](


### PR DESCRIPTION
各entityがECHONET LiteプロトコルのどのEPCによるものか分かるようにする。
entityのdetailsを選択することで参照可能。