### PR TITLE
Update Home Assistant requirement to version 2026.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The integration automatically creates repair issues when:
 
 ## Requirements
 
-- Home Assistant 2024.1 or later
+- Home Assistant 2026.3 or later
 
 ## Acknowledgments
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "HEMS echonet lite",
+  "homeassistant": "2026.3.0",
   "zip_release": true,
   "filename": "echonet_lite.zip"
 }


### PR DESCRIPTION
Update the Home Assistant requirement in the documentation and configuration files to ensure compatibility with version 2026.3.