### PR TITLE
Sync generated definitions and integration updates

### DIFF
--- a/custom_components/echonet_lite/__init__.py
+++ b/custom_components/echonet_lite/__init__.py
@@ -29,9 +29,6 @@ from .const import (
     DISCOVERY_INTERVAL,
     DOMAIN,
     EPC_INSTALLATION_LOCATION,
-    EPC_MANUFACTURER_CODE,
-    EPC_PRODUCT_CODE,
-    EPC_SERIAL_NUMBER,
     EXCLUDED_EPCS_BY_CLASS,
     RUNTIME_MONITOR_INTERVAL,
     RUNTIME_MONITOR_MAX_SILENCE,
@@ -155,9 +152,6 @@ def _build_fast_poll_epcs() -> dict[int, frozenset[int]]:
 
 _FAST_POLL_EPCS: Final[dict[int, frozenset[int]]] = _build_fast_poll_epcs()
 
-# EPCs to request during node discovery (in addition to identification and instance list)
-_DISCOVERY_EPCS: Final = [EPC_MANUFACTURER_CODE, EPC_PRODUCT_CODE, EPC_SERIAL_NUMBER]
-
 
 async def async_migrate_entry(
     hass: HomeAssistant, entry: EchonetLiteConfigEntry
@@ -202,7 +196,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: EchonetLiteConfigEntry) 
     client = HemsClient(
         interface=interface,
         poll_interval=DISCOVERY_INTERVAL,
-        extra_epcs=_DISCOVERY_EPCS,
     )
 
     # Determine which device class codes to accept

--- a/custom_components/echonet_lite/const.py
+++ b/custom_components/echonet_lite/const.py
@@ -90,9 +90,6 @@ CLASS_CODE_CONTROLLER = 0x05FF
 # Common (super class, 0x80-0x9F) EPCs.
 EPC_OPERATION_STATUS = 0x80
 EPC_INSTALLATION_LOCATION = 0x81
-EPC_MANUFACTURER_CODE = 0x8A
-EPC_PRODUCT_CODE = 0x8C
-EPC_SERIAL_NUMBER = 0x8D
 
 # Class-specific EPCs used by the climate / fan platforms.
 # 0xA0 has different semantic names per class (fan speed for HOME AC,

--- a/custom_components/echonet_lite/entity.py
+++ b/custom_components/echonet_lite/entity.py
@@ -63,8 +63,8 @@ def infer_platform(entity: EntityDefinition) -> Platform | None:
     Decision matrix:
         | Data shape    | readable + writable | readable only | write-only         |
         |---------------|---------------------|---------------|-----------         |
-        | 2 enum values | switch              | binary_sensor | None (skip)        |
-        | 3+ enum vals  | select              | sensor (ENUM) | None (skip)        |
+        | true/false enum | switch            | binary_sensor | None (skip)        |
+        | other enum values | select          | sensor (ENUM) | None (skip)        |
         | 1 enum value  | None (skip)         | None (skip)   | button             |
         | numeric       | number              | sensor        | None (skip)        |
         | numericValue  | None (skip)         | None (skip)   | None (skip)        |
@@ -82,7 +82,7 @@ def infer_platform(entity: EntityDefinition) -> Platform | None:
             if len(entity.enum_values) == 1:
                 # Single enum value on readable property is skipped
                 return None
-            if len(entity.enum_values) == 2:
+            if entity.is_binary:
                 return Platform.SWITCH if writable else Platform.BINARY_SENSOR
             return Platform.SELECT if writable else Platform.SENSOR
         if entity.format is None:

--- a/custom_components/echonet_lite/manifest.json
+++ b/custom_components/echonet_lite/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/sayurin/hems_echonet_lite/issues",
   "loggers": ["pyhems"],
   "quality_scale": "silver",
-  "requirements": ["pyhems==0.8.7"],
+  "requirements": ["pyhems==0.8.8"],
   "single_config_entry": true,
   "version": "0.8.6"
 }

--- a/custom_components/echonet_lite/strings.json
+++ b/custom_components/echonet_lite/strings.json
@@ -12,6 +12,7 @@
     "air_circulation": "Air circulation",
     "air_flow_rate_setting": "Air flow rate setting",
     "automatic": "Automatic",
+    "automatic_selection_mode": "Automatic selection mode",
     "automatic_water_heating_setting": "Automatic water heating setting",
     "bath_operation_status_monitor": "Bath Operation Status Monitor",
     "bath_water_volume_setting_4": "Bath water volume setting 4",
@@ -90,9 +91,11 @@
     "measured_instantaneous_electric_power": "Measured instantaneous electric power",
     "measured_instantaneous_voltages_between_r_and_sn": "Measured instantaneous voltages - Between R and S(N)",
     "measured_instantaneous_voltages_between_sn_and_t": "Measured instantaneous voltages - Between S(N) and T",
+    "measured_outdoor_air_temperature": "Measured outdoor air temperature",
     "measured_temperature_of_water_in_water_heater": "Measured temperature of water in water heater",
     "measured_value_of_co2_concentration": "Measured value of CO2 concentration",
     "measured_value_of_room_relative_humidity": "Measured value of room relative humidity",
+    "measured_value_of_room_temperature": "Measured value of room temperature",
     "minimummaximum_charging_electric_energy_maximum_charging_electric_energy": "Minimum/maximum charging electric energy - Maximum charging electric energy",
     "minimummaximum_charging_electric_energy_minimum_charging_electric_energy": "Minimum/maximum charging electric energy - Minimum charging electric energy",
     "mute_off": "Mute OFF",
@@ -100,6 +103,7 @@
     "mute_setting": "Mute setting",
     "night_lighting": "Night lighting",
     "no_lighting": "No lighting",
+    "no_mode_specified": "No mode specified",
     "no_setting": "No setting",
     "no_time_synchronization": "No time synchronization",
     "node_unit": "Node unit",
@@ -112,6 +116,7 @@
     "not_detected": "Not detected",
     "not_heating": "Not Heating",
     "not_removed": "Not removed",
+    "not_specified": "Not specified",
     "not_supplying_hot_water": "Not supplying hot water",
     "number_of_effective_digits_for_cumulative_amount_of_active_electric_energy": "Number of effective digits for cumulative amount of active electric energy",
     "number_of_effective_digits_for_cumulative_amounts_of_electric_energy": "Number of effective digits for cumulative amounts of electric energy",
@@ -157,6 +162,7 @@
     "special_operation_setting": "Special operation setting",
     "special_state": "Special state",
     "standard": "Standard",
+    "steaming": "Steaming",
     "stop": "Stop",
     "stopped_halfway": "Stopped halfway",
     "supplying_hot_water": "Supplying hot water",
@@ -183,6 +189,7 @@
     "vehicle_connection_confirmation": "Vehicle connection confirmation",
     "ventilation_air_flow_rate_setting": "Ventilation air flow rate setting",
     "ventilation_auto_setting": "Ventilation Auto setting",
+    "ventilation_function_setting": "Ventilation function setting",
     "volume_setting": "Volume setting",
     "water_is_heating": "Water is heating.",
     "water_is_not_heating": "Water is not heating.",
@@ -364,6 +371,9 @@
     "class_03b7": {
       "name": "Refrigerator"
     },
+    "class_03b8": {
+      "name": "combination microwave oven (electronic oven)"
+    },
     "class_03b9": {
       "name": "Cooking heater"
     },
@@ -387,6 +397,12 @@
     },
     "class_0602": {
       "name": "Television"
+    },
+    "class_0f01": {
+      "name": "User-defined device (0x0F01)"
+    },
+    "class_0f02": {
+      "name": "User-defined device (0x0F02)"
     },
     "unknown_class": {
       "name": "ECHONET Lite device {class_code}"
@@ -439,8 +455,8 @@
       "class_0130_epc_ab": {
         "name": "Non-priority state",
         "state": {
-          "off": "Non-priority",
-          "on": "[%key:common::state::normal%]"
+          "off": "[%key:common::state::normal%]",
+          "on": "Non-priority"
         }
       },
       "class_0134_epc_c1": {
@@ -478,7 +494,7 @@
           "on": "Found"
         }
       },
-      "class_0135_epc_f1_custom_000005_01": {
+      "class_0135_epc_f1_000005_01": {
         "name": "Illuminance",
         "state": {
           "off": "Dark",
@@ -495,8 +511,8 @@
       "class_0157_epc_ab": {
         "name": "[%key:component::echonet_lite::common::special_state%]",
         "state": {
-          "off": "[%key:component::echonet_lite::common::special_state%]",
-          "on": "[%key:component::echonet_lite::common::normal_operation%]"
+          "off": "[%key:component::echonet_lite::common::normal_operation%]",
+          "on": "[%key:component::echonet_lite::common::special_state%]"
         }
       },
       "class_0260_epc_c2": {
@@ -663,8 +679,8 @@
       "class_03b7_epc_a6": {
         "name": "Icemaker tank status",
         "state": {
-          "off": "There is no water left in the icemaker tank or the icemaker tank has not been positioned correctly in the refrigerator.",
-          "on": "Icemaker tank contains water."
+          "off": "Icemaker tank contains water.",
+          "on": "There is no water left in the icemaker tank or the icemaker tank has not been positioned correctly in the refrigerator."
         }
       },
       "class_03b7_epc_b0": {
@@ -716,6 +732,13 @@
           "on": "[%key:common::state::open%]"
         }
       },
+      "class_03b8_epc_b0": {
+        "name": "[%key:component::echonet_lite::common::door_openclose_status%]",
+        "state": {
+          "off": "door closed",
+          "on": "[%key:component::echonet_lite::common::door_open%]"
+        }
+      },
       "class_03bb_epc_b0": {
         "name": "Cover closure status",
         "state": {
@@ -742,20 +765,6 @@
         "state": {
           "off": "[%key:common::state::closed%]",
           "on": "[%key:common::state::open%]"
-        }
-      },
-      "class_03ce_epc_d2": {
-        "name": "This property indicates refrigerator type, such as built-in or separate.",
-        "state": {
-          "off": "Built-in type",
-          "on": "Separate type"
-        }
-      },
-      "class_03ce_epc_d4": {
-        "name": "This property indicates the purpose of the showcase, either refrigeration or freezing.",
-        "state": {
-          "off": "Freezing",
-          "on": "Refrigeration"
         }
       },
       "class_03ce_epc_e7": {
@@ -789,8 +798,8 @@
       "class_0602_epc_b1": {
         "name": "Character string setting acceptance status",
         "state": {
-          "off": "Busy",
-          "on": "Ready"
+          "off": "Ready",
+          "on": "Busy"
         }
       }
     },
@@ -1242,6 +1251,12 @@
       "class_03b7_epc_ed": {
         "name": "Multi-refrigerating mode compartment temperature level setting"
       },
+      "class_03b8_epc_e4": {
+        "name": "Food temperature setting"
+      },
+      "class_03b8_epc_e7": {
+        "name": "Microwave heating power setting"
+      },
       "class_03b9_epc_e3": {
         "name": "Heating temperature setting - Left stove temperature setting"
       },
@@ -1289,6 +1304,9 @@
       },
       "class_05ff_epc_c2": {
         "name": "Index"
+      },
+      "class_0f02_epc_b3_000006": {
+        "name": "[%key:component::echonet_lite::common::set_temperature_value%]"
       }
     },
     "select": {
@@ -1460,7 +1478,7 @@
         }
       },
       "class_0130_epc_c0": {
-        "name": "Ventilation function setting",
+        "name": "[%key:component::echonet_lite::common::ventilation_function_setting%]",
         "state": {
           "off": "[%key:common::state::off%]",
           "on_intake": "Ventilation function ON (intake direction)",
@@ -1540,6 +1558,13 @@
           "level_6": "[%key:component::echonet_lite::common::level_6%]",
           "level_7": "[%key:component::echonet_lite::common::level_7%]",
           "level_8": "[%key:component::echonet_lite::common::level_8%]"
+        }
+      },
+      "class_0134_epc_b1": {
+        "name": "Ventilation method setting",
+        "state": {
+          "air_conditioning": "Air conditioning ventilation",
+          "blowing": "Blowing ventilation"
         }
       },
       "class_0134_epc_b2": {
@@ -1947,6 +1972,13 @@
           "undefined": "[%key:component::echonet_lite::common::no_setting%]"
         }
       },
+      "class_027a_epc_e0": {
+        "name": "[%key:component::echonet_lite::common::operation_mode_setting%]",
+        "state": {
+          "cooling": "[%key:component::echonet_lite::common::cooling%]",
+          "heating": "[%key:component::echonet_lite::common::heating%]"
+        }
+      },
       "class_027a_epc_e5": {
         "name": "[%key:component::echonet_lite::common::special_operation_setting%]",
         "state": {
@@ -1998,6 +2030,13 @@
           "off": "[%key:common::state::off%]",
           "timer1": "[%key:component::echonet_lite::common::timer_1%]",
           "timer2": "[%key:component::echonet_lite::common::timer_2%]"
+        }
+      },
+      "class_027c_epc_d2": {
+        "name": "Designated power generation status",
+        "state": {
+          "load_following": "Load following power generation",
+          "maximum_rating": "Power generation at the maximum rating"
         }
       },
       "class_027d_epc_c1": {
@@ -2084,7 +2123,7 @@
         "name": "Owner classification",
         "state": {
           "individual": "Individual",
-          "not_specified": "Not specified",
+          "not_specified": "[%key:component::echonet_lite::common::not_specified%]",
           "private_sector_company": "Private sector company",
           "public_waterworks_company": "Public waterworks company"
         }
@@ -2155,6 +2194,13 @@
           "prioritizing_electricity_sales": "Prioritizing electricity sales"
         }
       },
+      "class_02a7_epc_c0": {
+        "name": "Control point",
+        "state": {
+          "device_point": "Device point",
+          "power_receiving_point": "Power receiving point"
+        }
+      },
       "class_03b7_epc_a0": {
         "name": "Quick freeze function setting",
         "state": {
@@ -2177,6 +2223,105 @@
           "disable": "Disable icemaker",
           "enable": "Enable icemaker",
           "standby": "[%key:common::state::standby%]"
+        }
+      },
+      "class_03b8_epc_b2": {
+        "name": "Heating setting",
+        "state": {
+          "start_restart_heating_heating_started_restarted": "Start/restart heating (heating started/restarted)",
+          "stop_heating_heating_stopped": "Stop heating (heating stopped)",
+          "suspend_heating_heating_suspended": "Suspend heating (heating suspended)"
+        }
+      },
+      "class_03b8_epc_d0": {
+        "name": "Automatic heating menu setting",
+        "state": {
+          "boiling_fruit_flower_vegetables": "Boiling fruit/flower vegetables",
+          "boiling_leafy_vegetables": "Boiling leafy vegetables",
+          "boiling_root_vegetables": "Boiling root vegetables",
+          "chawan_mushi": "Chawan-mushi",
+          "chiffon_cakes": "Chiffon cakes",
+          "cookies": "Cookies",
+          "cooking_rice": "Cooking rice",
+          "cream_puffs": "Cream puffs",
+          "defrosting_meat": "Defrosting meat",
+          "defrosting_sashimi": "Defrosting sashimi",
+          "fries": "Fries",
+          "fully_automatic": "Fully automatic",
+          "gratins": "Gratins",
+          "hamburger_steaks": "Hamburger steaks",
+          "milk": "Milk",
+          "no_automatic_heating_cycle_specified": "No automatic heating cycle specified",
+          "reheating_boiled_rice": "Reheating boiled rice",
+          "reheating_cooked_dish": "Reheating cooked dish",
+          "reheating_fries": "Reheating fries",
+          "rolls": "Rolls",
+          "sake": "Sake",
+          "sponge_cakes": "Sponge cakes",
+          "toast": "Toast"
+        }
+      },
+      "class_03b8_epc_d1": {
+        "name": "Oven mode setting",
+        "state": {
+          "automatic_selection_mode": "[%key:component::echonet_lite::common::automatic_selection_mode%]",
+          "circulation_oven_mode": "Circulation oven mode",
+          "convection_oven_mode": "Convection oven mode",
+          "hybrid_oven_mode": "Hybrid oven mode",
+          "no_sub_mode_specified": "No sub-mode specified"
+        }
+      },
+      "class_03b8_epc_d5": {
+        "name": "Oven preheating setting",
+        "state": {
+          "not_specified": "[%key:component::echonet_lite::common::not_specified%]",
+          "with_preheating": "With preheating",
+          "without_preheating": "Without preheating"
+        }
+      },
+      "class_03b8_epc_d6": {
+        "name": "Fermenting mode setting",
+        "state": {
+          "automatic_selection_mode": "[%key:component::echonet_lite::common::automatic_selection_mode%]",
+          "circulation_fermentation_mode": "Circulation fermentation mode",
+          "convection_fermentation_mode": "Convection fermentation mode",
+          "hybrid_fermentation_mode": "Hybrid fermentation mode",
+          "microwave_fermentation_mode": "Microwave fermentation mode",
+          "no_mode_specified": "[%key:component::echonet_lite::common::no_mode_specified%]"
+        }
+      },
+      "class_03b8_epc_e0": {
+        "name": "Heating mode setting",
+        "state": {
+          "defrosting": "[%key:component::echonet_lite::common::defrosting%]",
+          "fermenting": "Fermenting",
+          "grill": "Grill",
+          "microwave_heating": "Microwave heating",
+          "no_mode_specified": "[%key:component::echonet_lite::common::no_mode_specified%]",
+          "oven": "Oven",
+          "steaming": "[%key:component::echonet_lite::common::steaming%]",
+          "stewing": "Stewing",
+          "toaster": "Toaster",
+          "two_stage_microwave_heating": "Two-stage microwave heating"
+        }
+      },
+      "class_03b8_epc_e1": {
+        "name": "Automatic heating setting",
+        "state": {
+          "automatic": "[%key:component::echonet_lite::common::automatic%]",
+          "manual": "[%key:common::state::manual%]",
+          "not_specified": "[%key:component::echonet_lite::common::not_specified%]"
+        }
+      },
+      "class_03b8_epc_e2": {
+        "name": "Automatic heating level setting",
+        "state": {
+          "level1": "[%key:component::echonet_lite::common::level_1%]",
+          "level2": "[%key:component::echonet_lite::common::level_2%]",
+          "level3": "[%key:component::echonet_lite::common::level_3%]",
+          "level4": "[%key:component::echonet_lite::common::level_4%]",
+          "level5": "[%key:component::echonet_lite::common::level_5%]",
+          "not_specified": "[%key:component::echonet_lite::common::not_specified%]"
         }
       },
       "class_03ce_epc_b0": {
@@ -2301,6 +2446,37 @@
           "washing": "Washing only",
           "washing_rinsing": "Washing + all rinsing processes",
           "washing_rinsing_without_final": "Washing + rinsing (excluding the final rinsing)"
+        }
+      },
+      "class_03d4_epc_b0": {
+        "name": "[%key:component::echonet_lite::common::operation_mode_setting%]",
+        "state": {
+          "cooling": "[%key:component::echonet_lite::common::cooling%]",
+          "non_cooling": "[%key:component::echonet_lite::common::non_cooling%]"
+        }
+      },
+      "class_0f01_epc_b0_000006": {
+        "name": "[%key:component::echonet_lite::common::operation_mode_setting%]",
+        "state": {
+          "auto": "[%key:common::state::auto%]",
+          "circulation": "[%key:component::echonet_lite::common::air_circulation%]",
+          "cooling": "[%key:component::echonet_lite::common::cooling%]",
+          "dehumidification": "[%key:component::echonet_lite::common::dehumidification%]",
+          "heating": "[%key:component::echonet_lite::common::heating%]",
+          "other": "[%key:component::echonet_lite::common::other%]"
+        }
+      },
+      "class_0f01_epc_c2_000006": {
+        "name": "[%key:component::echonet_lite::common::ventilation_air_flow_rate_setting%]",
+        "state": {
+          "level_1": "[%key:component::echonet_lite::common::level_1%]",
+          "level_2": "[%key:component::echonet_lite::common::level_2%]",
+          "level_3": "[%key:component::echonet_lite::common::level_3%]",
+          "level_4": "[%key:component::echonet_lite::common::level_4%]",
+          "level_5": "[%key:component::echonet_lite::common::level_5%]",
+          "level_6": "[%key:component::echonet_lite::common::level_6%]",
+          "level_7": "[%key:component::echonet_lite::common::level_7%]",
+          "level_8": "[%key:component::echonet_lite::common::level_8%]"
         }
       },
       "installation_location_code": {
@@ -2431,7 +2607,7 @@
         "name": "[%key:component::echonet_lite::common::measured_value_of_room_relative_humidity%]"
       },
       "class_0130_epc_bb": {
-        "name": "Measured value of room temperature"
+        "name": "[%key:component::echonet_lite::common::measured_value_of_room_temperature%]"
       },
       "class_0130_epc_bc": {
         "name": "Set temperature value of user remote control"
@@ -2440,7 +2616,7 @@
         "name": "Measured cooled air temperature"
       },
       "class_0130_epc_be": {
-        "name": "Measured outdoor air temperature"
+        "name": "[%key:component::echonet_lite::common::measured_outdoor_air_temperature%]"
       },
       "class_0134_epc_b9": {
         "name": "Measured value of electric current consumption"
@@ -2469,13 +2645,13 @@
       "class_0134_epc_d5": {
         "name": "Measured value of discharging air relative humidity"
       },
-      "class_0135_epc_f1_custom_000005_03": {
+      "class_0135_epc_f1_000005_03": {
         "name": "Temperature"
       },
-      "class_0135_epc_f1_custom_000005_04": {
+      "class_0135_epc_f1_000005_04": {
         "name": "Humidity"
       },
-      "class_0135_epc_f1_custom_000005_1c": {
+      "class_0135_epc_f1_000005_1c": {
         "name": "PM2.5"
       },
       "class_0156_epc_ae": {
@@ -2704,40 +2880,40 @@
       "class_0279_epc_e3": {
         "name": "Measured cumulative amount of electric energy sold"
       },
-      "class_0279_epc_f2_custom_000005_00": {
+      "class_0279_epc_f2_000005": {
         "name": "Input Voltage 1"
       },
-      "class_0279_epc_f2_custom_000005_02": {
+      "class_0279_epc_f2_000005_02": {
         "name": "Input Voltage 2"
       },
-      "class_0279_epc_f2_custom_000005_04": {
+      "class_0279_epc_f2_000005_04": {
         "name": "Input Voltage 3"
       },
-      "class_0279_epc_f2_custom_000005_06": {
+      "class_0279_epc_f2_000005_06": {
         "name": "Input Voltage 4"
       },
-      "class_0279_epc_f3_custom_000005_00": {
+      "class_0279_epc_f3_000005": {
         "name": "Input Current 1"
       },
-      "class_0279_epc_f3_custom_000005_01": {
+      "class_0279_epc_f3_000005_01": {
         "name": "Input Current 2"
       },
-      "class_0279_epc_f3_custom_000005_02": {
+      "class_0279_epc_f3_000005_02": {
         "name": "Input Current 3"
       },
-      "class_0279_epc_f3_custom_000005_03": {
+      "class_0279_epc_f3_000005_03": {
         "name": "Input Current 4"
       },
-      "class_0279_epc_f4_custom_000005_00": {
+      "class_0279_epc_f4_000005": {
         "name": "Input Power 1"
       },
-      "class_0279_epc_f4_custom_000005_02": {
+      "class_0279_epc_f4_000005_02": {
         "name": "Input Power 2"
       },
-      "class_0279_epc_f4_custom_000005_04": {
+      "class_0279_epc_f4_000005_04": {
         "name": "Input Power 3"
       },
-      "class_0279_epc_f4_custom_000005_06": {
+      "class_0279_epc_f4_000005_06": {
         "name": "Input Power 4"
       },
       "class_027a_epc_e3": {
@@ -3571,13 +3747,26 @@
       "class_03b7_epc_dc": {
         "name": "[%key:component::echonet_lite::common::rated_power_consumption%]"
       },
+      "class_03b8_epc_b1": {
+        "name": "Heating status",
+        "state": {
+          "heating": "[%key:component::echonet_lite::common::heating%]",
+          "heating_suspended": "Heating suspended",
+          "heating_temporarily_stopped_for_manual_cooking_action": "Heating temporarily stopped for manual cooking action",
+          "initialstate": "Initial state",
+          "preheat_temperature_maintenance": "Preheat temperature maintenance",
+          "preheating": "[%key:component::echonet_lite::common::preheating%]",
+          "reporting_completion_of_heating_cycle": "Reporting completion of heating cycle",
+          "setting": "Setting"
+        }
+      },
       "class_03bb_epc_b1": {
         "name": "Rice cooking status",
         "state": {
           "completion": "Rice cooking completion",
           "cooking": "Rice cooking",
           "preheating": "[%key:component::echonet_lite::common::preheating%]",
-          "steaming": "Steaming",
+          "steaming": "[%key:component::echonet_lite::common::steaming%]",
           "stop": "[%key:common::state::stopped%]"
         }
       },
@@ -3590,6 +3779,13 @@
           "inverter": "Inverter",
           "non_fluorocarbon_inverter": "Non-fluorocarbon inverter (CO2)",
           "other": "[%key:component::echonet_lite::common::other%]"
+        }
+      },
+      "class_03ce_epc_d2": {
+        "name": "This property indicates refrigerator type, such as built-in or separate.",
+        "state": {
+          "built_in": "Built-in type",
+          "separate": "Separate type"
         }
       },
       "class_03ce_epc_d3": {
@@ -3606,6 +3802,13 @@
           "reach_in": "Reach-in type",
           "triple_glass": "Triple glass type",
           "walk_in": "Walk-in type"
+        }
+      },
+      "class_03ce_epc_d4": {
+        "name": "This property indicates the purpose of the showcase, either refrigeration or freezing.",
+        "state": {
+          "freezing": "Freezing",
+          "refrigeration": "Refrigeration"
         }
       },
       "class_03ce_epc_e3": {
@@ -3688,17 +3891,23 @@
       "class_05ff_epc_cb": {
         "name": "Registered information renewal version information of the device to be controlled"
       },
-      "class_05ff_epc_f2_custom_000005_00": {
+      "class_05ff_epc_f2_000005": {
         "name": "Instantaneous Electric Power Sold"
       },
-      "class_05ff_epc_f3_custom_000005_00": {
+      "class_05ff_epc_f3_000005": {
         "name": "Instantaneous Electric Power Bought"
       },
-      "class_05ff_epc_f4_custom_000005_00": {
+      "class_05ff_epc_f4_000005": {
         "name": "Cumulative Electric Energy Sold"
       },
-      "class_05ff_epc_f5_custom_000005_00": {
+      "class_05ff_epc_f5_000005": {
         "name": "Cumulative Electric Energy Bought"
+      },
+      "class_0f01_epc_be_000006": {
+        "name": "[%key:component::echonet_lite::common::measured_outdoor_air_temperature%]"
+      },
+      "class_0f02_epc_bb_000006": {
+        "name": "[%key:component::echonet_lite::common::measured_value_of_room_temperature%]"
       },
       "cumulative_energy": {
         "name": "Channel {channel} cumulative energy"
@@ -3764,13 +3973,6 @@
         "state": {
           "off": "[%key:component::echonet_lite::common::non_auto%]",
           "on": "[%key:common::state::auto%]"
-        }
-      },
-      "class_0134_epc_b1": {
-        "name": "Ventilation method setting",
-        "state": {
-          "off": "Air conditioning ventilation",
-          "on": "Blowing ventilation"
         }
       },
       "class_0134_epc_bf": {
@@ -4018,13 +4220,6 @@
           "on": "[%key:common::state::on%]"
         }
       },
-      "class_027a_epc_e0": {
-        "name": "[%key:component::echonet_lite::common::operation_mode_setting%]",
-        "state": {
-          "off": "[%key:component::echonet_lite::common::cooling%]",
-          "on": "[%key:component::echonet_lite::common::heating%]"
-        }
-      },
       "class_027b_epc_90": {
         "name": "[%key:component::echonet_lite::common::on_timer_reservation_setting%]",
         "state": {
@@ -4044,13 +4239,6 @@
         "state": {
           "off": "Power generation OFF",
           "on": "Power generation ON"
-        }
-      },
-      "class_027c_epc_d2": {
-        "name": "Designated power generation status",
-        "state": {
-          "off": "Load following power generation",
-          "on": "Power generation at the maximum rating"
         }
       },
       "class_027d_epc_cc": {
@@ -4114,13 +4302,6 @@
         "state": {
           "off": "[%key:component::echonet_lite::common::no_setting%]",
           "on": "[%key:component::echonet_lite::common::set%]"
-        }
-      },
-      "class_02a7_epc_c0": {
-        "name": "Control point",
-        "state": {
-          "off": "Power receiving point",
-          "on": "Device point"
         }
       },
       "class_02a7_epc_c8": {
@@ -4235,13 +4416,6 @@
           "on": "[%key:common::state::locked%]"
         }
       },
-      "class_03d4_epc_b0": {
-        "name": "[%key:component::echonet_lite::common::operation_mode_setting%]",
-        "state": {
-          "off": "[%key:component::echonet_lite::common::non_cooling%]",
-          "on": "[%key:component::echonet_lite::common::cooling%]"
-        }
-      },
       "class_03d4_epc_e2": {
         "name": "Indicates compressor ON/OFF status.",
         "state": {
@@ -4254,6 +4428,20 @@
         "state": {
           "off": "Displaying disabled",
           "on": "Displaying enabled"
+        }
+      },
+      "class_0f01_epc_c0_000006": {
+        "name": "[%key:component::echonet_lite::common::ventilation_function_setting%]",
+        "state": {
+          "off": "Ventilation function OFF",
+          "on": "Ventilation function ON"
+        }
+      },
+      "class_0f02_epc_8f_000006": {
+        "name": "Keep operation setting",
+        "state": {
+          "off": "Operating in keep mode",
+          "on": "Operating in normal mode"
         }
       }
     },

--- a/custom_components/echonet_lite/translations/en.json
+++ b/custom_components/echonet_lite/translations/en.json
@@ -12,6 +12,7 @@
         "air_circulation": "Air circulation",
         "air_flow_rate_setting": "Air flow rate setting",
         "automatic": "Automatic",
+        "automatic_selection_mode": "Automatic selection mode",
         "automatic_water_heating_setting": "Automatic water heating setting",
         "bath_operation_status_monitor": "Bath Operation Status Monitor",
         "bath_water_volume_setting_4": "Bath water volume setting 4",
@@ -90,9 +91,11 @@
         "measured_instantaneous_electric_power": "Measured instantaneous electric power",
         "measured_instantaneous_voltages_between_r_and_sn": "Measured instantaneous voltages - Between R and S(N)",
         "measured_instantaneous_voltages_between_sn_and_t": "Measured instantaneous voltages - Between S(N) and T",
+        "measured_outdoor_air_temperature": "Measured outdoor air temperature",
         "measured_temperature_of_water_in_water_heater": "Measured temperature of water in water heater",
         "measured_value_of_co2_concentration": "Measured value of CO2 concentration",
         "measured_value_of_room_relative_humidity": "Measured value of room relative humidity",
+        "measured_value_of_room_temperature": "Measured value of room temperature",
         "minimummaximum_charging_electric_energy_maximum_charging_electric_energy": "Minimum/maximum charging electric energy - Maximum charging electric energy",
         "minimummaximum_charging_electric_energy_minimum_charging_electric_energy": "Minimum/maximum charging electric energy - Minimum charging electric energy",
         "mute_off": "Mute OFF",
@@ -100,6 +103,7 @@
         "mute_setting": "Mute setting",
         "night_lighting": "Night lighting",
         "no_lighting": "No lighting",
+        "no_mode_specified": "No mode specified",
         "no_setting": "No setting",
         "no_time_synchronization": "No time synchronization",
         "node_unit": "Node unit",
@@ -112,6 +116,7 @@
         "not_detected": "Not detected",
         "not_heating": "Not Heating",
         "not_removed": "Not removed",
+        "not_specified": "Not specified",
         "not_supplying_hot_water": "Not supplying hot water",
         "number_of_effective_digits_for_cumulative_amount_of_active_electric_energy": "Number of effective digits for cumulative amount of active electric energy",
         "number_of_effective_digits_for_cumulative_amounts_of_electric_energy": "Number of effective digits for cumulative amounts of electric energy",
@@ -157,6 +162,7 @@
         "special_operation_setting": "Special operation setting",
         "special_state": "Special state",
         "standard": "Standard",
+        "steaming": "Steaming",
         "stop": "Stop",
         "stopped_halfway": "Stopped halfway",
         "supplying_hot_water": "Supplying hot water",
@@ -183,6 +189,7 @@
         "vehicle_connection_confirmation": "Vehicle connection confirmation",
         "ventilation_air_flow_rate_setting": "Ventilation air flow rate setting",
         "ventilation_auto_setting": "Ventilation Auto setting",
+        "ventilation_function_setting": "Ventilation function setting",
         "volume_setting": "Volume setting",
         "water_is_heating": "Water is heating.",
         "water_is_not_heating": "Water is not heating.",
@@ -364,6 +371,9 @@
         "class_03b7": {
             "name": "Refrigerator"
         },
+        "class_03b8": {
+            "name": "combination microwave oven (electronic oven)"
+        },
         "class_03b9": {
             "name": "Cooking heater"
         },
@@ -387,6 +397,12 @@
         },
         "class_0602": {
             "name": "Television"
+        },
+        "class_0f01": {
+            "name": "User-defined device (0x0F01)"
+        },
+        "class_0f02": {
+            "name": "User-defined device (0x0F02)"
         },
         "unknown_class": {
             "name": "ECHONET Lite device {class_code}"
@@ -439,8 +455,8 @@
             "class_0130_epc_ab": {
                 "name": "Non-priority state",
                 "state": {
-                    "off": "Non-priority",
-                    "on": "Normal"
+                    "off": "Normal",
+                    "on": "Non-priority"
                 }
             },
             "class_0134_epc_c1": {
@@ -478,7 +494,7 @@
                     "on": "Found"
                 }
             },
-            "class_0135_epc_f1_custom_000005_01": {
+            "class_0135_epc_f1_000005_01": {
                 "name": "Illuminance",
                 "state": {
                     "off": "Dark",
@@ -495,8 +511,8 @@
             "class_0157_epc_ab": {
                 "name": "Special state",
                 "state": {
-                    "off": "Special state",
-                    "on": "Normal Operation"
+                    "off": "Normal Operation",
+                    "on": "Special state"
                 }
             },
             "class_0260_epc_c2": {
@@ -663,8 +679,8 @@
             "class_03b7_epc_a6": {
                 "name": "Icemaker tank status",
                 "state": {
-                    "off": "There is no water left in the icemaker tank or the icemaker tank has not been positioned correctly in the refrigerator.",
-                    "on": "Icemaker tank contains water."
+                    "off": "Icemaker tank contains water.",
+                    "on": "There is no water left in the icemaker tank or the icemaker tank has not been positioned correctly in the refrigerator."
                 }
             },
             "class_03b7_epc_b0": {
@@ -716,6 +732,13 @@
                     "on": "Open"
                 }
             },
+            "class_03b8_epc_b0": {
+                "name": "Door open/close status",
+                "state": {
+                    "off": "door closed",
+                    "on": "Door open"
+                }
+            },
             "class_03bb_epc_b0": {
                 "name": "Cover closure status",
                 "state": {
@@ -742,20 +765,6 @@
                 "state": {
                     "off": "Closed",
                     "on": "Open"
-                }
-            },
-            "class_03ce_epc_d2": {
-                "name": "This property indicates refrigerator type, such as built-in or separate.",
-                "state": {
-                    "off": "Built-in type",
-                    "on": "Separate type"
-                }
-            },
-            "class_03ce_epc_d4": {
-                "name": "This property indicates the purpose of the showcase, either refrigeration or freezing.",
-                "state": {
-                    "off": "Freezing",
-                    "on": "Refrigeration"
                 }
             },
             "class_03ce_epc_e7": {
@@ -789,8 +798,8 @@
             "class_0602_epc_b1": {
                 "name": "Character string setting acceptance status",
                 "state": {
-                    "off": "Busy",
-                    "on": "Ready"
+                    "off": "Ready",
+                    "on": "Busy"
                 }
             }
         },
@@ -1242,6 +1251,12 @@
             "class_03b7_epc_ed": {
                 "name": "Multi-refrigerating mode compartment temperature level setting"
             },
+            "class_03b8_epc_e4": {
+                "name": "Food temperature setting"
+            },
+            "class_03b8_epc_e7": {
+                "name": "Microwave heating power setting"
+            },
             "class_03b9_epc_e3": {
                 "name": "Heating temperature setting - Left stove temperature setting"
             },
@@ -1289,6 +1304,9 @@
             },
             "class_05ff_epc_c2": {
                 "name": "Index"
+            },
+            "class_0f02_epc_b3_000006": {
+                "name": "Set temperature value"
             }
         },
         "select": {
@@ -1540,6 +1558,13 @@
                     "level_6": "Level 6",
                     "level_7": "Level 7",
                     "level_8": "Level 8"
+                }
+            },
+            "class_0134_epc_b1": {
+                "name": "Ventilation method setting",
+                "state": {
+                    "air_conditioning": "Air conditioning ventilation",
+                    "blowing": "Blowing ventilation"
                 }
             },
             "class_0134_epc_b2": {
@@ -1947,6 +1972,13 @@
                     "undefined": "No setting"
                 }
             },
+            "class_027a_epc_e0": {
+                "name": "Operation mode setting",
+                "state": {
+                    "cooling": "Cooling",
+                    "heating": "Heating"
+                }
+            },
             "class_027a_epc_e5": {
                 "name": "Special operation setting",
                 "state": {
@@ -1998,6 +2030,13 @@
                     "off": "Off",
                     "timer1": "Timer 1",
                     "timer2": "Timer 2"
+                }
+            },
+            "class_027c_epc_d2": {
+                "name": "Designated power generation status",
+                "state": {
+                    "load_following": "Load following power generation",
+                    "maximum_rating": "Power generation at the maximum rating"
                 }
             },
             "class_027d_epc_c1": {
@@ -2155,6 +2194,13 @@
                     "prioritizing_electricity_sales": "Prioritizing electricity sales"
                 }
             },
+            "class_02a7_epc_c0": {
+                "name": "Control point",
+                "state": {
+                    "device_point": "Device point",
+                    "power_receiving_point": "Power receiving point"
+                }
+            },
             "class_03b7_epc_a0": {
                 "name": "Quick freeze function setting",
                 "state": {
@@ -2177,6 +2223,105 @@
                     "disable": "Disable icemaker",
                     "enable": "Enable icemaker",
                     "standby": "Standby"
+                }
+            },
+            "class_03b8_epc_b2": {
+                "name": "Heating setting",
+                "state": {
+                    "start_restart_heating_heating_started_restarted": "Start/restart heating (heating started/restarted)",
+                    "stop_heating_heating_stopped": "Stop heating (heating stopped)",
+                    "suspend_heating_heating_suspended": "Suspend heating (heating suspended)"
+                }
+            },
+            "class_03b8_epc_d0": {
+                "name": "Automatic heating menu setting",
+                "state": {
+                    "boiling_fruit_flower_vegetables": "Boiling fruit/flower vegetables",
+                    "boiling_leafy_vegetables": "Boiling leafy vegetables",
+                    "boiling_root_vegetables": "Boiling root vegetables",
+                    "chawan_mushi": "Chawan-mushi",
+                    "chiffon_cakes": "Chiffon cakes",
+                    "cookies": "Cookies",
+                    "cooking_rice": "Cooking rice",
+                    "cream_puffs": "Cream puffs",
+                    "defrosting_meat": "Defrosting meat",
+                    "defrosting_sashimi": "Defrosting sashimi",
+                    "fries": "Fries",
+                    "fully_automatic": "Fully automatic",
+                    "gratins": "Gratins",
+                    "hamburger_steaks": "Hamburger steaks",
+                    "milk": "Milk",
+                    "no_automatic_heating_cycle_specified": "No automatic heating cycle specified",
+                    "reheating_boiled_rice": "Reheating boiled rice",
+                    "reheating_cooked_dish": "Reheating cooked dish",
+                    "reheating_fries": "Reheating fries",
+                    "rolls": "Rolls",
+                    "sake": "Sake",
+                    "sponge_cakes": "Sponge cakes",
+                    "toast": "Toast"
+                }
+            },
+            "class_03b8_epc_d1": {
+                "name": "Oven mode setting",
+                "state": {
+                    "automatic_selection_mode": "Automatic selection mode",
+                    "circulation_oven_mode": "Circulation oven mode",
+                    "convection_oven_mode": "Convection oven mode",
+                    "hybrid_oven_mode": "Hybrid oven mode",
+                    "no_sub_mode_specified": "No sub-mode specified"
+                }
+            },
+            "class_03b8_epc_d5": {
+                "name": "Oven preheating setting",
+                "state": {
+                    "not_specified": "Not specified",
+                    "with_preheating": "With preheating",
+                    "without_preheating": "Without preheating"
+                }
+            },
+            "class_03b8_epc_d6": {
+                "name": "Fermenting mode setting",
+                "state": {
+                    "automatic_selection_mode": "Automatic selection mode",
+                    "circulation_fermentation_mode": "Circulation fermentation mode",
+                    "convection_fermentation_mode": "Convection fermentation mode",
+                    "hybrid_fermentation_mode": "Hybrid fermentation mode",
+                    "microwave_fermentation_mode": "Microwave fermentation mode",
+                    "no_mode_specified": "No mode specified"
+                }
+            },
+            "class_03b8_epc_e0": {
+                "name": "Heating mode setting",
+                "state": {
+                    "defrosting": "Defrosting",
+                    "fermenting": "Fermenting",
+                    "grill": "Grill",
+                    "microwave_heating": "Microwave heating",
+                    "no_mode_specified": "No mode specified",
+                    "oven": "Oven",
+                    "steaming": "Steaming",
+                    "stewing": "Stewing",
+                    "toaster": "Toaster",
+                    "two_stage_microwave_heating": "Two-stage microwave heating"
+                }
+            },
+            "class_03b8_epc_e1": {
+                "name": "Automatic heating setting",
+                "state": {
+                    "automatic": "Automatic",
+                    "manual": "Manual",
+                    "not_specified": "Not specified"
+                }
+            },
+            "class_03b8_epc_e2": {
+                "name": "Automatic heating level setting",
+                "state": {
+                    "level1": "Level 1",
+                    "level2": "Level 2",
+                    "level3": "Level 3",
+                    "level4": "Level 4",
+                    "level5": "Level 5",
+                    "not_specified": "Not specified"
                 }
             },
             "class_03ce_epc_b0": {
@@ -2301,6 +2446,37 @@
                     "washing": "Washing only",
                     "washing_rinsing": "Washing + all rinsing processes",
                     "washing_rinsing_without_final": "Washing + rinsing (excluding the final rinsing)"
+                }
+            },
+            "class_03d4_epc_b0": {
+                "name": "Operation mode setting",
+                "state": {
+                    "cooling": "Cooling",
+                    "non_cooling": "Non-cooling"
+                }
+            },
+            "class_0f01_epc_b0_000006": {
+                "name": "Operation mode setting",
+                "state": {
+                    "auto": "Auto",
+                    "circulation": "Air circulation",
+                    "cooling": "Cooling",
+                    "dehumidification": "Dehumidification",
+                    "heating": "Heating",
+                    "other": "Other"
+                }
+            },
+            "class_0f01_epc_c2_000006": {
+                "name": "Ventilation air flow rate setting",
+                "state": {
+                    "level_1": "Level 1",
+                    "level_2": "Level 2",
+                    "level_3": "Level 3",
+                    "level_4": "Level 4",
+                    "level_5": "Level 5",
+                    "level_6": "Level 6",
+                    "level_7": "Level 7",
+                    "level_8": "Level 8"
                 }
             },
             "installation_location_code": {
@@ -2469,13 +2645,13 @@
             "class_0134_epc_d5": {
                 "name": "Measured value of discharging air relative humidity"
             },
-            "class_0135_epc_f1_custom_000005_03": {
+            "class_0135_epc_f1_000005_03": {
                 "name": "Temperature"
             },
-            "class_0135_epc_f1_custom_000005_04": {
+            "class_0135_epc_f1_000005_04": {
                 "name": "Humidity"
             },
-            "class_0135_epc_f1_custom_000005_1c": {
+            "class_0135_epc_f1_000005_1c": {
                 "name": "PM2.5"
             },
             "class_0156_epc_ae": {
@@ -2704,40 +2880,40 @@
             "class_0279_epc_e3": {
                 "name": "Measured cumulative amount of electric energy sold"
             },
-            "class_0279_epc_f2_custom_000005_00": {
+            "class_0279_epc_f2_000005": {
                 "name": "Input Voltage 1"
             },
-            "class_0279_epc_f2_custom_000005_02": {
+            "class_0279_epc_f2_000005_02": {
                 "name": "Input Voltage 2"
             },
-            "class_0279_epc_f2_custom_000005_04": {
+            "class_0279_epc_f2_000005_04": {
                 "name": "Input Voltage 3"
             },
-            "class_0279_epc_f2_custom_000005_06": {
+            "class_0279_epc_f2_000005_06": {
                 "name": "Input Voltage 4"
             },
-            "class_0279_epc_f3_custom_000005_00": {
+            "class_0279_epc_f3_000005": {
                 "name": "Input Current 1"
             },
-            "class_0279_epc_f3_custom_000005_01": {
+            "class_0279_epc_f3_000005_01": {
                 "name": "Input Current 2"
             },
-            "class_0279_epc_f3_custom_000005_02": {
+            "class_0279_epc_f3_000005_02": {
                 "name": "Input Current 3"
             },
-            "class_0279_epc_f3_custom_000005_03": {
+            "class_0279_epc_f3_000005_03": {
                 "name": "Input Current 4"
             },
-            "class_0279_epc_f4_custom_000005_00": {
+            "class_0279_epc_f4_000005": {
                 "name": "Input Power 1"
             },
-            "class_0279_epc_f4_custom_000005_02": {
+            "class_0279_epc_f4_000005_02": {
                 "name": "Input Power 2"
             },
-            "class_0279_epc_f4_custom_000005_04": {
+            "class_0279_epc_f4_000005_04": {
                 "name": "Input Power 3"
             },
-            "class_0279_epc_f4_custom_000005_06": {
+            "class_0279_epc_f4_000005_06": {
                 "name": "Input Power 4"
             },
             "class_027a_epc_e3": {
@@ -3571,6 +3747,19 @@
             "class_03b7_epc_dc": {
                 "name": "Rated power consumption"
             },
+            "class_03b8_epc_b1": {
+                "name": "Heating status",
+                "state": {
+                    "heating": "Heating",
+                    "heating_suspended": "Heating suspended",
+                    "heating_temporarily_stopped_for_manual_cooking_action": "Heating temporarily stopped for manual cooking action",
+                    "initialstate": "Initial state",
+                    "preheat_temperature_maintenance": "Preheat temperature maintenance",
+                    "preheating": "Preheating",
+                    "reporting_completion_of_heating_cycle": "Reporting completion of heating cycle",
+                    "setting": "Setting"
+                }
+            },
             "class_03bb_epc_b1": {
                 "name": "Rice cooking status",
                 "state": {
@@ -3592,6 +3781,13 @@
                     "other": "Other"
                 }
             },
+            "class_03ce_epc_d2": {
+                "name": "This property indicates refrigerator type, such as built-in or separate.",
+                "state": {
+                    "built_in": "Built-in type",
+                    "separate": "Separate type"
+                }
+            },
             "class_03ce_epc_d3": {
                 "name": "This property indicates the shape of the showcase.",
                 "state": {
@@ -3606,6 +3802,13 @@
                     "reach_in": "Reach-in type",
                     "triple_glass": "Triple glass type",
                     "walk_in": "Walk-in type"
+                }
+            },
+            "class_03ce_epc_d4": {
+                "name": "This property indicates the purpose of the showcase, either refrigeration or freezing.",
+                "state": {
+                    "freezing": "Freezing",
+                    "refrigeration": "Refrigeration"
                 }
             },
             "class_03ce_epc_e3": {
@@ -3688,17 +3891,23 @@
             "class_05ff_epc_cb": {
                 "name": "Registered information renewal version information of the device to be controlled"
             },
-            "class_05ff_epc_f2_custom_000005_00": {
+            "class_05ff_epc_f2_000005": {
                 "name": "Instantaneous Electric Power Sold"
             },
-            "class_05ff_epc_f3_custom_000005_00": {
+            "class_05ff_epc_f3_000005": {
                 "name": "Instantaneous Electric Power Bought"
             },
-            "class_05ff_epc_f4_custom_000005_00": {
+            "class_05ff_epc_f4_000005": {
                 "name": "Cumulative Electric Energy Sold"
             },
-            "class_05ff_epc_f5_custom_000005_00": {
+            "class_05ff_epc_f5_000005": {
                 "name": "Cumulative Electric Energy Bought"
+            },
+            "class_0f01_epc_be_000006": {
+                "name": "Measured outdoor air temperature"
+            },
+            "class_0f02_epc_bb_000006": {
+                "name": "Measured value of room temperature"
             },
             "cumulative_energy": {
                 "name": "Channel {channel} cumulative energy"
@@ -3764,13 +3973,6 @@
                 "state": {
                     "off": "Non-auto",
                     "on": "Auto"
-                }
-            },
-            "class_0134_epc_b1": {
-                "name": "Ventilation method setting",
-                "state": {
-                    "off": "Air conditioning ventilation",
-                    "on": "Blowing ventilation"
                 }
             },
             "class_0134_epc_bf": {
@@ -4018,13 +4220,6 @@
                     "on": "On"
                 }
             },
-            "class_027a_epc_e0": {
-                "name": "Operation mode setting",
-                "state": {
-                    "off": "Cooling",
-                    "on": "Heating"
-                }
-            },
             "class_027b_epc_90": {
                 "name": "ON timer reservation setting",
                 "state": {
@@ -4044,13 +4239,6 @@
                 "state": {
                     "off": "Power generation OFF",
                     "on": "Power generation ON"
-                }
-            },
-            "class_027c_epc_d2": {
-                "name": "Designated power generation status",
-                "state": {
-                    "off": "Load following power generation",
-                    "on": "Power generation at the maximum rating"
                 }
             },
             "class_027d_epc_cc": {
@@ -4114,13 +4302,6 @@
                 "state": {
                     "off": "No setting",
                     "on": "Set"
-                }
-            },
-            "class_02a7_epc_c0": {
-                "name": "Control point",
-                "state": {
-                    "off": "Power receiving point",
-                    "on": "Device point"
                 }
             },
             "class_02a7_epc_c8": {
@@ -4235,13 +4416,6 @@
                     "on": "Locked"
                 }
             },
-            "class_03d4_epc_b0": {
-                "name": "Operation mode setting",
-                "state": {
-                    "off": "Non-cooling",
-                    "on": "Cooling"
-                }
-            },
             "class_03d4_epc_e2": {
                 "name": "Indicates compressor ON/OFF status.",
                 "state": {
@@ -4254,6 +4428,20 @@
                 "state": {
                     "off": "Displaying disabled",
                     "on": "Displaying enabled"
+                }
+            },
+            "class_0f01_epc_c0_000006": {
+                "name": "Ventilation function setting",
+                "state": {
+                    "off": "Ventilation function OFF",
+                    "on": "Ventilation function ON"
+                }
+            },
+            "class_0f02_epc_8f_000006": {
+                "name": "Keep operation setting",
+                "state": {
+                    "off": "Operating in keep mode",
+                    "on": "Operating in normal mode"
                 }
             }
         },

--- a/custom_components/echonet_lite/translations/ja.json
+++ b/custom_components/echonet_lite/translations/ja.json
@@ -175,6 +175,9 @@
     "class_03b7": {
       "name": "冷凍冷蔵庫"
     },
+    "class_03b8": {
+      "name": "オーブンレンジ"
+    },
     "class_03b9": {
       "name": "クッキングヒータ"
     },
@@ -198,6 +201,12 @@
     },
     "class_0602": {
       "name": "テレビ"
+    },
+    "class_0f01": {
+      "name": "ユーザ定義デバイス (0x0F01)"
+    },
+    "class_0f02": {
+      "name": "ユーザ定義デバイス (0x0F02)"
     },
     "unknown_class": {
       "name": "ECHONET Liteデバイス {class_code}"
@@ -289,7 +298,7 @@
           "on": "フィルタ交換時期通知有"
         }
       },
-      "class_0135_epc_f1_custom_000005_01": {
+      "class_0135_epc_f1_000005_01": {
         "name": "照度",
         "state": {
           "off": "暗い",
@@ -527,6 +536,13 @@
           "on": "ドア開"
         }
       },
+      "class_03b8_epc_b0": {
+        "name": "ドア開閉状態",
+        "state": {
+          "off": "ドア閉",
+          "on": "ドア開"
+        }
+      },
       "class_03bb_epc_b0": {
         "name": "蓋開閉状態",
         "state": {
@@ -553,20 +569,6 @@
         "state": {
           "off": "クローズ",
           "on": "オープン"
-        }
-      },
-      "class_03ce_epc_d2": {
-        "name": "冷凍機内蔵型か冷凍機別置型かを示すショーケース構成情報",
-        "state": {
-          "off": "内蔵型",
-          "on": "別置型"
-        }
-      },
-      "class_03ce_epc_d4": {
-        "name": "冷蔵用途か冷凍用途かを示す庫内温度帯情報",
-        "state": {
-          "off": "冷凍",
-          "on": "冷蔵"
         }
       },
       "class_03ce_epc_e7": {
@@ -1053,6 +1055,12 @@
       "class_03b7_epc_ed": {
         "name": "切換室温度レベル設定"
       },
+      "class_03b8_epc_e4": {
+        "name": "仕上がり温度設定値"
+      },
+      "class_03b8_epc_e7": {
+        "name": "電子レンジ加熱出力設定値"
+      },
       "class_03b9_epc_e3": {
         "name": "加熱温度設定値 左コンロ設定温度"
       },
@@ -1100,6 +1108,9 @@
       },
       "class_05ff_epc_c2": {
         "name": "インデックス"
+      },
+      "class_0f02_epc_b3_000006": {
+        "name": "温度設定値"
       }
     },
     "select": {
@@ -1351,6 +1362,13 @@
           "level_6": "レベル6",
           "level_7": "レベル7",
           "level_8": "レベル8"
+        }
+      },
+      "class_0134_epc_b1": {
+        "name": "換気方式設定",
+        "state": {
+          "air_conditioning": "空調換気",
+          "blowing": "送風換気"
         }
       },
       "class_0134_epc_b2": {
@@ -1758,6 +1776,13 @@
           "undefined": "未設定"
         }
       },
+      "class_027a_epc_e0": {
+        "name": "運転モード設定",
+        "state": {
+          "cooling": "冷房",
+          "heating": "暖房"
+        }
+      },
       "class_027a_epc_e5": {
         "name": "特殊運転設定",
         "state": {
@@ -1809,6 +1834,13 @@
           "off": "タイマー切",
           "timer1": "タイマー1",
           "timer2": "タイマー2"
+        }
+      },
+      "class_027c_epc_d2": {
+        "name": "指定発電状態",
+        "state": {
+          "load_following": "負荷追従での発電",
+          "maximum_rating": "定格最大での発電"
         }
       },
       "class_027d_epc_c1": {
@@ -1966,6 +1998,13 @@
           "prioritizing_electricity_sales": "売電優先"
         }
       },
+      "class_02a7_epc_c0": {
+        "name": "制御ポイント",
+        "state": {
+          "device_point": "機器点",
+          "power_receiving_point": "受電点"
+        }
+      },
       "class_03b7_epc_a0": {
         "name": "急速冷凍動作設定",
         "state": {
@@ -1988,6 +2027,105 @@
           "disable": "製氷禁止",
           "enable": "製氷許可",
           "standby": "製氷一定時間禁止"
+        }
+      },
+      "class_03b8_epc_b2": {
+        "name": "加熱設定",
+        "state": {
+          "start_restart_heating_heating_started_restarted": "加熱開始・再開",
+          "stop_heating_heating_stopped": "加熱停止",
+          "suspend_heating_heating_suspended": "加熱一時停止"
+        }
+      },
+      "class_03b8_epc_d0": {
+        "name": "自動メニューコース設定",
+        "state": {
+          "boiling_fruit_flower_vegetables": "ゆで果花菜",
+          "boiling_leafy_vegetables": "ゆで葉菜",
+          "boiling_root_vegetables": "ゆで根菜",
+          "chawan_mushi": "茶碗蒸",
+          "chiffon_cakes": "シフォンケーキ",
+          "cookies": "クッキー",
+          "cooking_rice": "炊飯",
+          "cream_puffs": "シュー皮",
+          "defrosting_meat": "肉解凍",
+          "defrosting_sashimi": "さしみ解凍",
+          "fries": "フライ",
+          "fully_automatic": "全自動",
+          "gratins": "グラタン",
+          "hamburger_steaks": "ハンバーグ",
+          "milk": "牛乳",
+          "no_automatic_heating_cycle_specified": "未設定",
+          "reheating_boiled_rice": "ごはんあたため",
+          "reheating_cooked_dish": "おかずあたため",
+          "reheating_fries": "揚げ物再加熱",
+          "rolls": "ロールパン",
+          "sake": "お酒",
+          "sponge_cakes": "スポンジケーキ",
+          "toast": "食パン"
+        }
+      },
+      "class_03b8_epc_d1": {
+        "name": "オーブンモード設定",
+        "state": {
+          "automatic_selection_mode": "自動選択モード",
+          "circulation_oven_mode": "熱風オーブンモード",
+          "convection_oven_mode": "対流オーブンモード",
+          "hybrid_oven_mode": "複合オーブンモード",
+          "no_sub_mode_specified": "未設定"
+        }
+      },
+      "class_03b8_epc_d5": {
+        "name": "オーブン予熱設定",
+        "state": {
+          "not_specified": "未設定",
+          "with_preheating": "予熱あり",
+          "without_preheating": "予熱なし"
+        }
+      },
+      "class_03b8_epc_d6": {
+        "name": "発酵モード設定",
+        "state": {
+          "automatic_selection_mode": "自動選択モード",
+          "circulation_fermentation_mode": "熱風発酵モード",
+          "convection_fermentation_mode": "対流発酵モード",
+          "hybrid_fermentation_mode": "複合発酵モード",
+          "microwave_fermentation_mode": "電子レンジ発酵モード",
+          "no_mode_specified": "未設定"
+        }
+      },
+      "class_03b8_epc_e0": {
+        "name": "加熱モード設定",
+        "state": {
+          "defrosting": "解凍",
+          "fermenting": "発酵",
+          "grill": "グリル",
+          "microwave_heating": "電子レンジ加熱",
+          "no_mode_specified": "未設定",
+          "oven": "オーブン",
+          "steaming": "スチーム加熱",
+          "stewing": "煮込み",
+          "toaster": "トースト",
+          "two_stage_microwave_heating": "電子レンジ２段加熱"
+        }
+      },
+      "class_03b8_epc_e1": {
+        "name": "自動加熱設定",
+        "state": {
+          "automatic": "自動",
+          "manual": "マニュアル",
+          "not_specified": "未設定"
+        }
+      },
+      "class_03b8_epc_e2": {
+        "name": "自動加熱レベル設定",
+        "state": {
+          "level1": "Level 1",
+          "level2": "Level 2",
+          "level3": "Level 3",
+          "level4": "Level 4",
+          "level5": "Level 5",
+          "not_specified": "未設定"
         }
       },
       "class_03ce_epc_b0": {
@@ -2112,6 +2250,37 @@
           "washing": "洗いのみ",
           "washing_rinsing": "洗い＋全すすぎ",
           "washing_rinsing_without_final": "洗い+すすぎ (除く最終すすぎ)"
+        }
+      },
+      "class_03d4_epc_b0": {
+        "name": "運転モード設定",
+        "state": {
+          "cooling": "冷却",
+          "non_cooling": "非冷"
+        }
+      },
+      "class_0f01_epc_b0_000006": {
+        "name": "運転モード設定",
+        "state": {
+          "auto": "自動",
+          "circulation": "送風",
+          "cooling": "冷房",
+          "dehumidification": "除湿",
+          "heating": "暖房",
+          "other": "その他"
+        }
+      },
+      "class_0f01_epc_c2_000006": {
+        "name": "換気風量設定",
+        "state": {
+          "level_1": "レベル1",
+          "level_2": "レベル2",
+          "level_3": "レベル3",
+          "level_4": "レベル4",
+          "level_5": "レベル5",
+          "level_6": "レベル6",
+          "level_7": "レベル7",
+          "level_8": "レベル8"
         }
       },
       "installation_location_code": {
@@ -2280,13 +2449,13 @@
       "class_0134_epc_d5": {
         "name": "排気相対湿度計測値"
       },
-      "class_0135_epc_f1_custom_000005_03": {
+      "class_0135_epc_f1_000005_03": {
         "name": "温度"
       },
-      "class_0135_epc_f1_custom_000005_04": {
+      "class_0135_epc_f1_000005_04": {
         "name": "湿度"
       },
-      "class_0135_epc_f1_custom_000005_1c": {
+      "class_0135_epc_f1_000005_1c": {
         "name": "PM2.5"
       },
       "class_0156_epc_ae": {
@@ -2515,40 +2684,40 @@
       "class_0279_epc_e3": {
         "name": "積算売電電力量計測値"
       },
-      "class_0279_epc_f2_custom_000005_00": {
+      "class_0279_epc_f2_000005": {
         "name": "入力電圧1"
       },
-      "class_0279_epc_f2_custom_000005_02": {
+      "class_0279_epc_f2_000005_02": {
         "name": "入力電圧2"
       },
-      "class_0279_epc_f2_custom_000005_04": {
+      "class_0279_epc_f2_000005_04": {
         "name": "入力電圧3"
       },
-      "class_0279_epc_f2_custom_000005_06": {
+      "class_0279_epc_f2_000005_06": {
         "name": "入力電圧4"
       },
-      "class_0279_epc_f3_custom_000005_00": {
+      "class_0279_epc_f3_000005": {
         "name": "入力電流1"
       },
-      "class_0279_epc_f3_custom_000005_01": {
+      "class_0279_epc_f3_000005_01": {
         "name": "入力電流2"
       },
-      "class_0279_epc_f3_custom_000005_02": {
+      "class_0279_epc_f3_000005_02": {
         "name": "入力電流3"
       },
-      "class_0279_epc_f3_custom_000005_03": {
+      "class_0279_epc_f3_000005_03": {
         "name": "入力電流4"
       },
-      "class_0279_epc_f4_custom_000005_00": {
+      "class_0279_epc_f4_000005": {
         "name": "入力電力1"
       },
-      "class_0279_epc_f4_custom_000005_02": {
+      "class_0279_epc_f4_000005_02": {
         "name": "入力電力2"
       },
-      "class_0279_epc_f4_custom_000005_04": {
+      "class_0279_epc_f4_000005_04": {
         "name": "入力電力3"
       },
-      "class_0279_epc_f4_custom_000005_06": {
+      "class_0279_epc_f4_000005_06": {
         "name": "入力電力4"
       },
       "class_027a_epc_e3": {
@@ -3382,6 +3551,19 @@
       "class_03b7_epc_dc": {
         "name": "定格消費電力値"
       },
+      "class_03b8_epc_b1": {
+        "name": "加熱状態",
+        "state": {
+          "heating": "運転中",
+          "heating_suspended": "一時停止中",
+          "heating_temporarily_stopped_for_manual_cooking_action": "加熱途中報知一時停止中",
+          "initialstate": "初期状態",
+          "preheat_temperature_maintenance": "予熱完了保温中",
+          "preheating": "予熱中",
+          "reporting_completion_of_heating_cycle": "完了報知中",
+          "setting": "設定中"
+        }
+      },
       "class_03bb_epc_b1": {
         "name": "炊飯状態",
         "state": {
@@ -3403,6 +3585,13 @@
           "other": "その他"
         }
       },
+      "class_03ce_epc_d2": {
+        "name": "冷凍機内蔵型か冷凍機別置型かを示すショーケース構成情報",
+        "state": {
+          "built_in": "内蔵型",
+          "separate": "別置型"
+        }
+      },
       "class_03ce_epc_d3": {
         "name": "ショーケース形状情報",
         "state": {
@@ -3417,6 +3606,13 @@
           "reach_in": "リーチイン",
           "triple_glass": "三面ガラス式",
           "walk_in": "ウォークイン"
+        }
+      },
+      "class_03ce_epc_d4": {
+        "name": "冷蔵用途か冷凍用途かを示す庫内温度帯情報",
+        "state": {
+          "freezing": "冷凍",
+          "refrigeration": "冷蔵"
         }
       },
       "class_03ce_epc_e3": {
@@ -3499,17 +3695,23 @@
       "class_05ff_epc_cb": {
         "name": "管理対象機器登録情報更新バージョン情報"
       },
-      "class_05ff_epc_f2_custom_000005_00": {
+      "class_05ff_epc_f2_000005": {
         "name": "瞬時売電電力"
       },
-      "class_05ff_epc_f3_custom_000005_00": {
+      "class_05ff_epc_f3_000005": {
         "name": "瞬時買電電力"
       },
-      "class_05ff_epc_f4_custom_000005_00": {
+      "class_05ff_epc_f4_000005": {
         "name": "積算売電電力量"
       },
-      "class_05ff_epc_f5_custom_000005_00": {
+      "class_05ff_epc_f5_000005": {
         "name": "積算買電電力量"
+      },
+      "class_0f01_epc_be_000006": {
+        "name": "外気温度計測値"
+      },
+      "class_0f02_epc_bb_000006": {
+        "name": "室内温度計測値"
       },
       "cumulative_energy": {
         "name": "チャンネル {channel} 積算電力量"
@@ -3575,13 +3777,6 @@
         "state": {
           "off": "非AUTO",
           "on": "AUTO"
-        }
-      },
-      "class_0134_epc_b1": {
-        "name": "換気方式設定",
-        "state": {
-          "off": "空調換気",
-          "on": "送風換気"
         }
       },
       "class_0134_epc_bf": {
@@ -3829,13 +4024,6 @@
           "on": "予約入"
         }
       },
-      "class_027a_epc_e0": {
-        "name": "運転モード設定",
-        "state": {
-          "off": "冷房",
-          "on": "暖房"
-        }
-      },
       "class_027b_epc_90": {
         "name": "ON タイマ予約設定",
         "state": {
@@ -3855,13 +4043,6 @@
         "state": {
           "off": "発電停止",
           "on": "発電動作"
-        }
-      },
-      "class_027c_epc_d2": {
-        "name": "指定発電状態",
-        "state": {
-          "off": "負荷追従での発電",
-          "on": "定格最大での発電"
         }
       },
       "class_027d_epc_cc": {
@@ -3925,13 +4106,6 @@
         "state": {
           "off": "設定しない",
           "on": "設定する"
-        }
-      },
-      "class_02a7_epc_c0": {
-        "name": "制御ポイント",
-        "state": {
-          "off": "受電点",
-          "on": "機器点"
         }
       },
       "class_02a7_epc_c8": {
@@ -4046,13 +4220,6 @@
           "on": "ロック"
         }
       },
-      "class_03d4_epc_b0": {
-        "name": "運転モード設定",
-        "state": {
-          "off": "非冷",
-          "on": "冷却"
-        }
-      },
       "class_03d4_epc_e2": {
         "name": "コンプレッサ動作状態",
         "state": {
@@ -4065,6 +4232,20 @@
         "state": {
           "off": "非表示",
           "on": "表示"
+        }
+      },
+      "class_0f01_epc_c0_000006": {
+        "name": "換気モード設定",
+        "state": {
+          "off": "換気ON",
+          "on": "換気OFF"
+        }
+      },
+      "class_0f02_epc_8f_000006": {
+        "name": "キープ運転設定",
+        "state": {
+          "off": "キープON",
+          "on": "キープOFF"
         }
       }
     },


### PR DESCRIPTION
## Summary
- sync the ECHONET Lite entity platform behavior with the updated pyhems definitions
- treat only normalized `true`/`false` enums as switches or binary sensors
- regenerate English and Japanese translations and generated strings
- update the pyhems dependency to 0.8.8
- remove discovery EPCs that are now handled by pyhems

## Validation
- pyhems dependency and generated definitions were updated from the local pyhems checkout
- core ECHONET Lite tests: 352 passed
- integration-specific hassfest validation passed