### PR TITLE
Update device entry type and Home Assistant version

### DIFF
--- a/custom_components/echonet_lite/__init__.py
+++ b/custom_components/echonet_lite/__init__.py
@@ -267,7 +267,7 @@ async def _async_update_listener(
 async def async_remove_config_entry_device(
     hass: HomeAssistant,
     config_entry: EchonetLiteConfigEntry,
-    device_entry: dr.DeviceEntry,
+    device_entry: dr.AnyDeviceEntry,
 ) -> bool:
     """Remove a config entry from a device.
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "HEMS echonet lite",
-  "homeassistant": "2026.7.0",
+  "homeassistant": "2026.9.0b0",
   "zip_release": true,
   "filename": "echonet_lite.zip"
 }


### PR DESCRIPTION
Update the device entry type to `AnyDeviceEntry` and change the Home Assistant version to `2026.9.0b0` in the configuration.