### PR TITLE
Refactor runtime controller ownership

### DIFF
--- a/custom_components/echonet_lite/__init__.py
+++ b/custom_components/echonet_lite/__init__.py
@@ -1,7 +1,5 @@
 """The HEMS Echonet Lite integration."""
 
-import asyncio
-from contextlib import suppress
 import logging
 from typing import Final
 
@@ -36,7 +34,6 @@ from .const import (
 from .coordinator import EchonetLiteCoordinator
 from .runtime import (
     EchonetLiteConfigEntry,
-    EchonetLiteRuntimeData,
     RuntimeController,
     RuntimeHealth,
     RuntimeIssueMonitor,
@@ -207,13 +204,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: EchonetLiteConfigEntry) 
         class_code_filter=class_code_filter,
         fast_epcs=_FAST_POLL_EPCS,
     )
+
+    runtime_health = RuntimeHealth()
+
     coordinator = EchonetLiteCoordinator(
         hass,
         config_entry=entry,
         device_manager=device_manager,
+        health=runtime_health,
     )
-
-    runtime_health = RuntimeHealth()
 
     issue_monitor = RuntimeIssueMonitor(
         hass,
@@ -222,31 +221,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: EchonetLiteConfigEntry) 
         interval=RUNTIME_MONITOR_INTERVAL,
     )
 
+    property_poller = PropertyPoller(
+        device_manager,
+        poll_interval=DEFAULT_POLL_INTERVAL,
+        fast_poll_interval=DEFAULT_FAST_POLL_INTERVAL,
+    )
+
     controller = RuntimeController(
         hass,
         entry,
         client=client,
-        device_manager=device_manager,
         coordinator=coordinator,
+        property_poller=property_poller,
         issue_monitor=issue_monitor,
         health=runtime_health,
     )
 
     await controller.async_start()
 
-    property_poller = PropertyPoller(
-        device_manager,
-        poll_interval=DEFAULT_POLL_INTERVAL,
-        fast_poll_interval=DEFAULT_FAST_POLL_INTERVAL,
-    )
-    property_poller.start()
-
-    entry.runtime_data = EchonetLiteRuntimeData(
-        controller=controller,
-        property_poller=property_poller,
-        device_manager=device_manager,
-        device_info_cache={},
-    )
+    entry.runtime_data = controller
 
     # Reload entry when options change
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
@@ -272,7 +265,7 @@ async def async_remove_config_entry_device(
     Removal is permitted only when the device is no longer actively
     discovered on the local network (i.e. not present in coordinator data).
     """
-    coordinator = config_entry.runtime_data.controller.coordinator
+    coordinator = config_entry.runtime_data.coordinator
     return not device_entry.identifiers.intersection(
         (DOMAIN, device_key) for device_key in coordinator.data
     )
@@ -287,15 +280,6 @@ async def async_unload_entry(
 
     runtime = entry.runtime_data
     if runtime:
-        runtime.controller.unsubscribe_runtime()
-        runtime.controller.issue_monitor.stop()
-        runtime.property_poller.stop()
-        runtime.controller.discovery_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await runtime.controller.discovery_task
-        runtime.controller.event_consumer_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await runtime.controller.event_consumer_task
-        await runtime.controller.client.stop()
+        await runtime.async_stop()
 
     return True

--- a/custom_components/echonet_lite/coordinator.py
+++ b/custom_components/echonet_lite/coordinator.py
@@ -6,12 +6,13 @@ from typing import TYPE_CHECKING
 from pyhems import DeviceManager, HemsFrameEvent, HemsInstanceListEvent, NodeState
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
 
 if TYPE_CHECKING:
-    from .runtime import EchonetLiteConfigEntry
+    from .runtime import EchonetLiteConfigEntry, RuntimeHealth
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ class EchonetLiteCoordinator(DataUpdateCoordinator[dict[str, NodeState]]):
         *,
         config_entry: EchonetLiteConfigEntry,
         device_manager: DeviceManager,
+        health: RuntimeHealth,
     ) -> None:
         """Initialize the coordinator for a specific config entry."""
 
@@ -47,8 +49,20 @@ class EchonetLiteCoordinator(DataUpdateCoordinator[dict[str, NodeState]]):
         # snapshot right after startup; this default keeps ``.data`` iterable
         # for callers (and tests) that inspect it before the first update.
         self.data: dict[str, NodeState] = {}
-        self._last_runtime_activity_at: float | None = None
         self.device_manager = device_manager
+        # Per-node ``DeviceInfo`` cache keyed by ``node.device_key``. Built
+        # once on first entity instantiation for a node and shared by every
+        # entity platform bound to that node. Lives on the coordinator
+        # (rather than on the config entry's runtime data) since it shares
+        # the coordinator's per-entry lifetime and is only ever read via
+        # ``coordinator`` from entity setup.
+        self.device_info_cache: dict[str, DeviceInfo] = {}
+        # ``RuntimeHealth`` is the single canonical store for runtime health
+        # telemetry (client errors, restarts, activity). Kept here too so
+        # entities (which only have direct access to the coordinator via
+        # ``CoordinatorEntity``) can read ``last_runtime_activity_at``
+        # without reaching into ``RuntimeController``.
+        self._health = health
 
         # Wire DeviceManager callbacks to coordinator
         device_manager.on_device_added(self._on_device_added)
@@ -72,11 +86,11 @@ class EchonetLiteCoordinator(DataUpdateCoordinator[dict[str, NodeState]]):
     @property
     def last_runtime_activity_at(self) -> float | None:
         """Return the timestamp of the last runtime activity seen by HA."""
-        return self._last_runtime_activity_at
+        return self._health.last_runtime_activity_at
 
     def record_runtime_activity(self, timestamp: float) -> None:
         """Record the timestamp of the latest runtime activity."""
-        self._last_runtime_activity_at = timestamp
+        self._health.last_runtime_activity_at = timestamp
 
     async def async_process_frame_event(self, event: HemsFrameEvent) -> None:
         """Process a frame event via DeviceManager and notify listeners if updated."""

--- a/custom_components/echonet_lite/diagnostics.py
+++ b/custom_components/echonet_lite/diagnostics.py
@@ -157,7 +157,7 @@ async def async_get_config_entry_diagnostics(
     entry: EchonetLiteConfigEntry,
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    controller = entry.runtime_data.controller
+    controller = entry.runtime_data
     coordinator = controller.coordinator
     health = controller.health
 
@@ -201,13 +201,14 @@ async def async_get_device_diagnostics(
     if device_key is None:
         return {"error": "device_not_found", "reason": "missing_identifier"}
 
-    node = entry.runtime_data.controller.coordinator.data.get(device_key)
+    coordinator = entry.runtime_data.coordinator
+    node = coordinator.data.get(device_key)
     if node is None:
         return async_redact_data(
             {"device_key": device_key, "node_known": False}, TO_REDACT
         )
 
-    node_dict = _node_to_dict(node, entry.runtime_data.device_manager)
+    node_dict = _node_to_dict(node, coordinator.device_manager)
     _add_poller_stats(node_dict, device_key=node.device_key, entry=entry)
 
     return async_redact_data(node_dict, TO_REDACT)

--- a/custom_components/echonet_lite/entity.py
+++ b/custom_components/echonet_lite/entity.py
@@ -27,7 +27,7 @@ from .const import (
 )
 from .coordinator import EchonetLiteCoordinator
 from .prop import Prop
-from .runtime import EchonetLiteConfigEntry, EchonetLiteRuntimeData
+from .runtime import EchonetLiteConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,10 +101,10 @@ def infer_platform(entity: EntityDefinition) -> Platform | None:
 
 
 def _get_or_build_device_info(
-    runtime_data: EchonetLiteRuntimeData, node: NodeState
+    coordinator: EchonetLiteCoordinator, node: NodeState
 ) -> DeviceInfo:
     """Return the cached ``DeviceInfo`` for ``node``, building it on first use."""
-    cache = runtime_data.device_info_cache
+    cache = coordinator.device_info_cache
     if (cached := cache.get(node.device_key)) is not None:
         return cached
 
@@ -168,9 +168,7 @@ class EchonetLiteEntity(CoordinatorEntity[EchonetLiteCoordinator]):
 
         super().__init__(coordinator)
         self._node = node
-        self._attr_device_info = _get_or_build_device_info(
-            coordinator.config_entry.runtime_data, node
-        )
+        self._attr_device_info = _get_or_build_device_info(coordinator, node)
         # EPCs this entity is interested in, used to (un)subscribe with
         # DeviceManager so that a disabled entity's EPCs stop being polled.
         # Subclasses that manage more than one EPC (dedicated-platform
@@ -185,8 +183,7 @@ class EchonetLiteEntity(CoordinatorEntity[EchonetLiteCoordinator]):
     async def async_added_to_hass(self) -> None:
         """Subscribe this entity's EPCs for polling once added to hass."""
         await super().async_added_to_hass()
-        runtime = self.coordinator.config_entry.runtime_data
-        self._unsub_epc_subscription = runtime.device_manager.subscribe_epcs(
+        self._unsub_epc_subscription = self.coordinator.device_manager.subscribe_epcs(
             self._node.device_key, self._subscribed_epcs
         )
 
@@ -249,8 +246,8 @@ class EchonetLiteEntity(CoordinatorEntity[EchonetLiteCoordinator]):
                 translation_key="epc_not_writable",
                 translation_placeholders={"epc_list": hex_list},
             )
-        runtime = self.coordinator.config_entry.runtime_data
-        sent = await runtime.controller.client.set_properties(
+        controller = self.coordinator.config_entry.runtime_data
+        sent = await controller.client.set_properties(
             node_id=node.node_id,
             deoj=node.eoj,
             properties=properties,
@@ -263,7 +260,7 @@ class EchonetLiteEntity(CoordinatorEntity[EchonetLiteCoordinator]):
 
         # After a Set operation, schedule an earlier poll so the UI reflects the
         # updated device state sooner.
-        runtime.property_poller.schedule_immediate_poll(node.device_key)
+        controller.property_poller.schedule_immediate_poll(node.device_key)
 
     async def _async_send_prop[ValueT](self, prop: Prop[ValueT], value: ValueT) -> None:
         """Encode value via prop and send as a SetC request for this EPC.
@@ -604,7 +601,7 @@ def setup_echonet_lite_device_platform(
         async_add_entities: Callback to add entities
         entity_factory: Callable building entities for a given node.
     """
-    coordinator = entry.runtime_data.controller.coordinator
+    coordinator = entry.runtime_data.coordinator
     known_device_keys: set[str] = set()
 
     @callback
@@ -629,9 +626,7 @@ def setup_echonet_lite_device_platform(
             if not device_entities or not _has_enabled_entity_candidate(
                 coordinator.hass, platform_domain, device_entities
             ):
-                coordinator.config_entry.runtime_data.device_manager.subscribe_epcs(
-                    device_key, frozenset()
-                )
+                coordinator.device_manager.subscribe_epcs(device_key, frozenset())
             new_entities.extend(device_entities)
         if new_entities:
             async_add_entities(new_entities)

--- a/custom_components/echonet_lite/runtime.py
+++ b/custom_components/echonet_lite/runtime.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Callable
+import contextlib
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
@@ -9,7 +10,6 @@ import time
 from typing import Any
 
 from pyhems import (
-    DeviceManager,
     HemsClient,
     HemsErrorEvent,
     HemsFrameEvent,
@@ -22,7 +22,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import DOMAIN, ISSUE_RUNTIME_CLIENT_ERROR, ISSUE_RUNTIME_INACTIVE
@@ -34,12 +33,21 @@ _INITIAL_DISCOVERY_TIMEOUT = 30.0
 
 @dataclass(slots=True)
 class RuntimeHealth:
-    """Health metadata tracked for the runtime client."""
+    """Health metadata tracked for the runtime client.
+
+    The single canonical store for runtime health telemetry.
+    ``EchonetLiteCoordinator`` delegates its ``last_runtime_activity_at``
+    property to this object rather than keeping its own copy, so entities
+    (which only have direct access to the coordinator) and diagnostics
+    (which reaches this object via ``RuntimeController.health``) always see
+    the same value.
+    """
 
     last_client_error: str | None = None
     last_client_error_at: float | None = None
     last_restart_at: float | None = None
     restart_attempts: int = 0
+    last_runtime_activity_at: float | None = None
 
 
 class RuntimeIssueMonitor:
@@ -160,9 +168,18 @@ class RuntimeIssueMonitor:
 class RuntimeController:
     """Own the pyhems runtime lifecycle for a config entry.
 
-    Encapsulates the restart lock, event queue, event consumer task and
-    discovery task so that ``async_setup_entry`` can stay focused on
-    dependency wiring.
+    Stored directly as ``entry.runtime_data`` (see ``EchonetLiteConfigEntry``
+    below): it already exposes every object other modules need
+    (``client``, ``coordinator``, ``property_poller``, ``issue_monitor``,
+    ``health``), so a separate wrapper dataclass would only add a level of
+    indirection without owning any state of its own.
+
+    Encapsulates the restart lock, event queue, event consumer task,
+    discovery task and the adaptive property poller so that
+    ``async_setup_entry``/``async_unload_entry`` can stay focused on
+    dependency wiring: :meth:`async_start` and :meth:`async_stop` are the
+    single symmetric entry points for starting and tearing down everything
+    this class owns.
     """
 
     def __init__(
@@ -171,8 +188,8 @@ class RuntimeController:
         entry: EchonetLiteConfigEntry,
         *,
         client: HemsClient,
-        device_manager: DeviceManager,
         coordinator: EchonetLiteCoordinator,
+        property_poller: PropertyPoller,
         issue_monitor: RuntimeIssueMonitor,
         health: RuntimeHealth,
     ) -> None:
@@ -180,8 +197,8 @@ class RuntimeController:
         self._hass = hass
         self._entry = entry
         self.client = client
-        self._device_manager = device_manager
         self.coordinator = coordinator
+        self.property_poller = property_poller
         self.issue_monitor = issue_monitor
         self.health = health
         self._restart_lock = asyncio.Lock()
@@ -228,6 +245,26 @@ class RuntimeController:
             self._run_initial_discovery(),
             name="echonet_lite_discovery",
         )
+        self.property_poller.start()
+
+    async def async_stop(self) -> None:
+        """Undo everything started by :meth:`async_start`.
+
+        Mirrors ``async_setup_entry``/``async_unload_entry``'s previous
+        manual teardown sequence so ``async_unload_entry`` can call this as
+        a single step instead of reaching into the controller's tasks and
+        sub-objects directly.
+        """
+        self.unsubscribe_runtime()
+        self.issue_monitor.stop()
+        self.property_poller.stop()
+        self.discovery_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self.discovery_task
+        self.event_consumer_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self.event_consumer_task
+        await self.client.stop()
 
     async def _run_initial_discovery(self) -> None:
         """Run the initial probe and start recurring discovery."""
@@ -353,20 +390,9 @@ class RuntimeController:
             # A shallow copy is sufficient: ``NodeState`` values are owned
             # by ``DeviceManager`` and only mutated from the single event
             # consumer task, so concurrent readers see a consistent snapshot.
-            self.coordinator.async_set_updated_data(dict(self._device_manager.data))
+            self.coordinator.async_set_updated_data(
+                dict(self.coordinator.device_manager.data)
+            )
 
 
-@dataclass(slots=True)
-class EchonetLiteRuntimeData:
-    """Runtime data stored on the config entry."""
-
-    controller: RuntimeController
-    property_poller: PropertyPoller
-    device_manager: DeviceManager
-    # Per-node ``DeviceInfo`` cache keyed by ``node.device_key``. Built once
-    # on first entity instantiation for a node and shared by every entity
-    # platform bound to that node.
-    device_info_cache: dict[str, DeviceInfo]
-
-
-EchonetLiteConfigEntry = ConfigEntry[EchonetLiteRuntimeData]
+EchonetLiteConfigEntry = ConfigEntry[RuntimeController]


### PR DESCRIPTION
## Proposed change
Refactor the runtime data ownership in the ECHONET Lite integration.

- Move `device_info_cache` to `EchonetLiteCoordinator`.
- Remove the single-field `EchonetLiteRuntimeData` wrapper and store `RuntimeController` directly in `entry.runtime_data`.
- Update entity, diagnostics, and test access paths accordingly.
- Preserve the existing `DeviceEntry` annotation difference used by this custom integration.

This keeps each runtime object accessible from the object that owns its lifecycle and removes redundant indirection.
