### PR TITLE
Allow parallel ECHONET Lite entity updates

### DIFF
--- a/custom_components/echonet_lite/button.py
+++ b/custom_components/echonet_lite/button.py
@@ -19,7 +19,7 @@ from .entity import (
 from .prop import EnumProp
 from .runtime import EchonetLiteConfigEntry
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/echonet_lite/climate.py
+++ b/custom_components/echonet_lite/climate.py
@@ -42,7 +42,7 @@ from .runtime import EchonetLiteConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 _SUPPORTED_HVAC_MODES: list[HVACMode] = [
     HVACMode.OFF,

--- a/custom_components/echonet_lite/cover.py
+++ b/custom_components/echonet_lite/cover.py
@@ -29,7 +29,7 @@ from .entity import EchonetLiteEntity, setup_dedicated_platform
 from .prop import EnumProp, NumericProp
 from .runtime import EchonetLiteConfigEntry
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/echonet_lite/fan.py
+++ b/custom_components/echonet_lite/fan.py
@@ -33,7 +33,7 @@ from .runtime import EchonetLiteConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 # Ordered list of pyhems speed level keys (level_1 = slowest, level_8 = fastest)
 _SPEED_LEVELS = [

--- a/custom_components/echonet_lite/light.py
+++ b/custom_components/echonet_lite/light.py
@@ -30,7 +30,7 @@ from .entity import EchonetLiteEntity, setup_dedicated_platform
 from .prop import BinaryProp, EnumProp, NumericProp
 from .runtime import EchonetLiteConfigEntry
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 # Mapping between EPC 0xB1 (Light color setting) snake_case enum keys and the
 # kelvin presets exposed to Home Assistant.

--- a/custom_components/echonet_lite/lock.py
+++ b/custom_components/echonet_lite/lock.py
@@ -21,7 +21,7 @@ from .entity import EchonetLiteEntity, setup_dedicated_platform
 from .prop import BinaryProp, EnumProp
 from .runtime import EchonetLiteConfigEntry
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/echonet_lite/number.py
+++ b/custom_components/echonet_lite/number.py
@@ -25,7 +25,7 @@ from .entity import (
 from .prop import NumericProp
 from .runtime import EchonetLiteConfigEntry
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 
 def _infer_device_class(

--- a/custom_components/echonet_lite/select.py
+++ b/custom_components/echonet_lite/select.py
@@ -1,5 +1,6 @@
 """Select platform for the HEMS Echonet Lite integration."""
 
+import asyncio
 from dataclasses import dataclass
 from typing import override
 
@@ -37,7 +38,9 @@ from .entity import (
 from .prop import EnumProp
 from .runtime import EchonetLiteConfigEntry
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
+
+_INSTALLATION_LOCATION_LOCK = asyncio.Lock()
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -210,18 +213,19 @@ class InstallationLocationCodeSelect(EchonetLiteEntity, SelectEntity):
     @override
     async def async_select_option(self, option: str) -> None:
         """Send updated location code while preserving the current NNN."""
-        new_llll = _LOCATION_KEY_TO_CODE[option]
-        if new_llll == 0:
-            # "unset" selected — write 0x00; forcing NNN=0 avoids generating
-            # the prohibited 0x01-0x07 range (17-byte format indicators).
-            await self._async_send_property(EPC_INSTALLATION_LOCATION, b"\x00")
-            return
-        fields = _decode_location_fields(self._node)
-        nnn = fields[1] if fields is not None else 0
-        edt = InstallationLocationCodec().encode(
-            InstallationLocation.from_code(new_llll, nnn)
-        )
-        await self._async_send_property(EPC_INSTALLATION_LOCATION, edt)
+        async with _INSTALLATION_LOCATION_LOCK:
+            new_llll = _LOCATION_KEY_TO_CODE[option]
+            if new_llll == 0:
+                # "unset" selected — write 0x00; forcing NNN=0 avoids generating
+                # the prohibited 0x01-0x07 range (17-byte format indicators).
+                await self._async_send_property(EPC_INSTALLATION_LOCATION, b"\x00")
+                return
+            fields = _decode_location_fields(self._node)
+            nnn = fields[1] if fields is not None else 0
+            edt = InstallationLocationCodec().encode(
+                InstallationLocation.from_code(new_llll, nnn)
+            )
+            await self._async_send_property(EPC_INSTALLATION_LOCATION, edt)
 
 
 class InstallationLocationNumberSelect(EchonetLiteEntity, SelectEntity):
@@ -268,15 +272,16 @@ class InstallationLocationNumberSelect(EchonetLiteEntity, SelectEntity):
     @override
     async def async_select_option(self, option: str) -> None:
         """Send updated location number while preserving the current LLLL."""
-        fields = _decode_location_fields(self._node)
-        if fields is None or fields[0] == 0:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="installation_location_number_unset",
+        async with _INSTALLATION_LOCATION_LOCK:
+            fields = _decode_location_fields(self._node)
+            if fields is None or fields[0] == 0:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="installation_location_number_unset",
+                )
+            llll = fields[0]
+            new_nnn = int(option)
+            edt = InstallationLocationCodec().encode(
+                InstallationLocation.from_code(llll, new_nnn)
             )
-        llll = fields[0]
-        new_nnn = int(option)
-        edt = InstallationLocationCodec().encode(
-            InstallationLocation.from_code(llll, new_nnn)
-        )
-        await self._async_send_property(EPC_INSTALLATION_LOCATION, edt)
+            await self._async_send_property(EPC_INSTALLATION_LOCATION, edt)

--- a/custom_components/echonet_lite/switch.py
+++ b/custom_components/echonet_lite/switch.py
@@ -19,7 +19,7 @@ from .entity import (
 from .prop import BinaryProp
 from .runtime import EchonetLiteConfigEntry
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/echonet_lite/water_heater.py
+++ b/custom_components/echonet_lite/water_heater.py
@@ -34,7 +34,7 @@ from .entity import EchonetLiteEntity, setup_dedicated_platform
 from .prop import BinaryProp, EnumProp, NumericProp
 from .runtime import EchonetLiteConfigEntry
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 _TRANSLATION_KEY = "electric_water_heater"
 


### PR DESCRIPTION
## Summary

Allow all ECHONET Lite entity platforms to process service calls in parallel by setting `PARALLEL_UPDATES = 0`.

Installation Location read-modify-write operations remain serialized with a global lock shared by the code and number select entities, preventing lost updates when they run concurrently.

The corresponding core integration tests pass with 354 tests and 98% coverage.