### PR TITLE
Update pyhems dependency and operation mode translations

### DIFF
--- a/custom_components/echonet_lite/manifest.json
+++ b/custom_components/echonet_lite/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/sayurin/hems_echonet_lite/issues",
   "loggers": ["pyhems"],
   "quality_scale": "silver",
-  "requirements": ["pyhems==0.8.8"],
+  "requirements": ["pyhems==0.8.9"],
   "single_config_entry": true,
   "version": "0.8.7"
 }

--- a/custom_components/echonet_lite/strings.json
+++ b/custom_components/echonet_lite/strings.json
@@ -2458,12 +2458,11 @@
       "class_0f01_epc_b0_000006": {
         "name": "[%key:component::echonet_lite::common::operation_mode_setting%]",
         "state": {
-          "auto": "[%key:common::state::auto%]",
           "circulation": "[%key:component::echonet_lite::common::air_circulation%]",
           "cooling": "[%key:component::echonet_lite::common::cooling%]",
-          "dehumidification": "[%key:component::echonet_lite::common::dehumidification%]",
-          "heating": "[%key:component::echonet_lite::common::heating%]",
-          "other": "[%key:component::echonet_lite::common::other%]"
+          "dehumidification": "Dehumidify (High)",
+          "dehumidification_low": "Dehumidify (Low)",
+          "heating": "[%key:component::echonet_lite::common::heating%]"
         }
       },
       "class_0f01_epc_c2_000006": {

--- a/custom_components/echonet_lite/translations/en.json
+++ b/custom_components/echonet_lite/translations/en.json
@@ -2458,12 +2458,11 @@
             "class_0f01_epc_b0_000006": {
                 "name": "Operation mode setting",
                 "state": {
-                    "auto": "Auto",
                     "circulation": "Air circulation",
                     "cooling": "Cooling",
-                    "dehumidification": "Dehumidification",
-                    "heating": "Heating",
-                    "other": "Other"
+                    "dehumidification": "Dehumidify (High)",
+                    "dehumidification_low": "Dehumidify (Low)",
+                    "heating": "Heating"
                 }
             },
             "class_0f01_epc_c2_000006": {

--- a/custom_components/echonet_lite/translations/ja.json
+++ b/custom_components/echonet_lite/translations/ja.json
@@ -2262,12 +2262,11 @@
       "class_0f01_epc_b0_000006": {
         "name": "運転モード設定",
         "state": {
-          "auto": "自動",
           "circulation": "送風",
           "cooling": "冷房",
-          "dehumidification": "除湿",
-          "heating": "暖房",
-          "other": "その他"
+          "dehumidification": "除湿強",
+          "dehumidification_low": "除湿弱",
+          "heating": "暖房"
         }
       },
       "class_0f01_epc_c2_000006": {


### PR DESCRIPTION
Update the integration to pyhems 0.8.9 and regenerate the operation mode translations to match the updated definitions.

This adds the distinct high and low dehumidification modes and removes operation mode entries that are no longer provided by pyhems.

Validation:
- JSON validation passed for manifest, strings, and translations
- `git diff --check` passed