### PR TITLE
Synchronize runtime and entity property sends

### DIFF
--- a/custom_components/echonet_lite/button.py
+++ b/custom_components/echonet_lite/button.py
@@ -87,4 +87,4 @@ class EchonetLiteButton(
     @override
     async def async_press(self) -> None:
         """Send the button press command via the pyhems runtime client."""
-        await self._async_send_prop(self.description.prop, self.description.press_value)
+        self._send_prop(self.description.prop, self.description.press_value)

--- a/custom_components/echonet_lite/climate.py
+++ b/custom_components/echonet_lite/climate.py
@@ -343,7 +343,7 @@ class EchonetLiteClimate(EchonetLiteEntity, ClimateEntity):
                 translation_key="unsupported_value",
                 translation_placeholders={"value": str(hvac_mode)},
             )
-        await self._async_send_properties(
+        self._send_properties(
             [
                 self.entity_description.op_mode_prop.make_property(pyhems_mode),
                 self.entity_description.op_status.make_property(True),
@@ -359,7 +359,7 @@ class EchonetLiteClimate(EchonetLiteEntity, ClimateEntity):
                 translation_key="epc_not_writable",
                 translation_placeholders={"epc_list": f"0x{EPC_OPERATION_STATUS:02X}"},
             )
-        await self._async_send_prop(self.entity_description.op_status, True)
+        self._send_prop(self.entity_description.op_status, True)
 
     @override
     async def async_turn_off(self) -> None:
@@ -370,7 +370,7 @@ class EchonetLiteClimate(EchonetLiteEntity, ClimateEntity):
                 translation_key="epc_not_writable",
                 translation_placeholders={"epc_list": f"0x{EPC_OPERATION_STATUS:02X}"},
             )
-        await self._async_send_prop(self.entity_description.op_status, False)
+        self._send_prop(self.entity_description.op_status, False)
 
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -390,7 +390,7 @@ class EchonetLiteClimate(EchonetLiteEntity, ClimateEntity):
             )
         temperature = float(kwargs[ATTR_TEMPERATURE])
         clamped = min(max(temperature, self._attr_min_temp), self._attr_max_temp)
-        await self._async_send_prop(self.entity_description.target_temp_prop, clamped)
+        self._send_prop(self.entity_description.target_temp_prop, clamped)
 
     @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
@@ -401,7 +401,7 @@ class EchonetLiteClimate(EchonetLiteEntity, ClimateEntity):
                 translation_key="unsupported_value",
                 translation_placeholders={"value": fan_mode},
             )
-        await self._async_send_prop(self.entity_description.fan_mode_prop, fan_mode)
+        self._send_prop(self.entity_description.fan_mode_prop, fan_mode)
 
     @override
     async def async_set_swing_mode(self, swing_mode: str) -> None:
@@ -413,7 +413,7 @@ class EchonetLiteClimate(EchonetLiteEntity, ClimateEntity):
                 translation_key="unsupported_value",
                 translation_placeholders={"value": swing_mode},
             )
-        await self._async_send_prop(
+        self._send_prop(
             self.entity_description.swing_mode_prop,
             pyhems_key,
         )

--- a/custom_components/echonet_lite/coordinator.py
+++ b/custom_components/echonet_lite/coordinator.py
@@ -92,7 +92,7 @@ class EchonetLiteCoordinator(DataUpdateCoordinator[dict[str, NodeState]]):
         """Record the timestamp of the latest runtime activity."""
         self._health.last_runtime_activity_at = timestamp
 
-    async def async_process_frame_event(self, event: HemsFrameEvent) -> None:
+    def process_frame_event(self, event: HemsFrameEvent) -> None:
         """Process a frame event via DeviceManager and notify listeners if updated."""
         self.device_manager.process_frame_event(event)
 

--- a/custom_components/echonet_lite/cover.py
+++ b/custom_components/echonet_lite/cover.py
@@ -183,38 +183,36 @@ class EchonetLiteCover(EchonetLiteEntity, CoverEntity):
     @override
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Send the open command (EPC 0xE0 = 0x41)."""
-        await self._async_send_prop(self.entity_description.open_close_prop, "open")
+        self._send_prop(self.entity_description.open_close_prop, "open")
 
     @override
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Send the close command (EPC 0xE0 = 0x42)."""
-        await self._async_send_prop(self.entity_description.open_close_prop, "close")
+        self._send_prop(self.entity_description.open_close_prop, "close")
 
     @override
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Send the stop command (EPC 0xE0 = 0x43)."""
-        await self._async_send_prop(self.entity_description.open_close_prop, "stop")
+        self._send_prop(self.entity_description.open_close_prop, "stop")
 
     @override
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set the degree-of-opening as a 0-100 percentage (EPC 0xE1)."""
         position = max(0, min(100, int(kwargs[ATTR_POSITION])))
-        await self._async_send_prop(
-            self.entity_description.position_prop, float(position)
-        )
+        self._send_prop(self.entity_description.position_prop, float(position))
 
     @override
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the slats fully (HA tilt 100 -> 180 deg)."""
-        await self._async_send_prop(self.entity_description.angle_prop, 180.0)
+        self._send_prop(self.entity_description.angle_prop, 180.0)
 
     @override
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the slats fully (HA tilt 0 -> 0 deg)."""
-        await self._async_send_prop(self.entity_description.angle_prop, 0.0)
+        self._send_prop(self.entity_description.angle_prop, 0.0)
 
     @override
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Set the slat angle (EPC 0xE2 0-180 deg) from HA tilt 0-100."""
         deg = _tilt_ha_to_deg(int(kwargs[ATTR_TILT_POSITION]))
-        await self._async_send_prop(self.entity_description.angle_prop, float(deg))
+        self._send_prop(self.entity_description.angle_prop, float(deg))

--- a/custom_components/echonet_lite/entity.py
+++ b/custom_components/echonet_lite/entity.py
@@ -214,7 +214,7 @@ class EchonetLiteEntity(CoordinatorEntity[EchonetLiteCoordinator]):
             return True
         return time.monotonic() - last_activity_at < self._runtime_silence_threshold
 
-    async def _async_send_property(self, epc: int, value: bytes) -> None:
+    def _send_property(self, epc: int, value: bytes) -> None:
         """Send a SetC request for a single EPC/value pair.
 
         Args:
@@ -224,9 +224,9 @@ class EchonetLiteEntity(CoordinatorEntity[EchonetLiteCoordinator]):
         Raises:
             HomeAssistantError: If the EPC is not writable by the device.
         """
-        await self._async_send_properties(properties=[Property(epc=epc, edt=value)])
+        self._send_properties(properties=[Property(epc=epc, edt=value)])
 
-    async def _async_send_properties(self, properties: list[Property]) -> None:
+    def _send_properties(self, properties: list[Property]) -> None:
         """Send a SetC request for multiple EPC/value pairs.
 
         Args:
@@ -247,7 +247,7 @@ class EchonetLiteEntity(CoordinatorEntity[EchonetLiteCoordinator]):
                 translation_placeholders={"epc_list": hex_list},
             )
         controller = self.coordinator.config_entry.runtime_data
-        sent = await controller.client.set_properties(
+        sent = controller.client.set_properties(
             node_id=node.node_id,
             deoj=node.eoj,
             properties=properties,
@@ -262,13 +262,13 @@ class EchonetLiteEntity(CoordinatorEntity[EchonetLiteCoordinator]):
         # updated device state sooner.
         controller.property_poller.schedule_immediate_poll(node.device_key)
 
-    async def _async_send_prop[ValueT](self, prop: Prop[ValueT], value: ValueT) -> None:
+    def _send_prop[ValueT](self, prop: Prop[ValueT], value: ValueT) -> None:
         """Encode value via prop and send as a SetC request for this EPC.
 
         Raises:
             HomeAssistantError: If the EPC is not writable by the device.
         """
-        await self._async_send_properties([prop.make_property(value)])
+        self._send_properties([prop.make_property(value)])
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/echonet_lite/fan.py
+++ b/custom_components/echonet_lite/fan.py
@@ -191,7 +191,7 @@ class EchonetLiteFan(EchonetLiteEntity, FanEntity):
 
         # Turn off the fan if percentage is explicitly set to 0
         if percentage == 0:
-            await self._async_send_prop(self.entity_description.op_status, False)
+            self._send_prop(self.entity_description.op_status, False)
             return
 
         properties: list[Property] = [
@@ -212,12 +212,12 @@ class EchonetLiteFan(EchonetLiteEntity, FanEntity):
                     )
                 )
 
-        await self._async_send_properties(properties)
+        self._send_properties(properties)
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
-        await self._async_send_prop(self.entity_description.op_status, False)
+        self._send_prop(self.entity_description.op_status, False)
 
     @override
     async def async_set_percentage(self, percentage: int) -> None:
@@ -230,7 +230,7 @@ class EchonetLiteFan(EchonetLiteEntity, FanEntity):
         is treated as OFF per HA convention.
         """
         if percentage == 0:
-            await self._async_send_prop(self.entity_description.op_status, False)
+            self._send_prop(self.entity_description.op_status, False)
             return
         if EPC_AIR_FLOW_LEVEL not in self._node.set_epcs:
             return
@@ -239,7 +239,7 @@ class EchonetLiteFan(EchonetLiteEntity, FanEntity):
             properties.append(self.entity_description.op_status.make_property(True))
         key = percentage_to_ordered_list_item(_SPEED_LEVELS, percentage)
         properties.append(self.entity_description.air_flow_prop.make_property(key))
-        await self._async_send_properties(properties)
+        self._send_properties(properties)
 
     @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -264,7 +264,7 @@ class EchonetLiteFan(EchonetLiteEntity, FanEntity):
             properties.append(
                 self.entity_description.air_flow_prop.make_property(PRESET_MODE_AUTO)
             )
-            await self._async_send_properties(properties)
+            self._send_properties(properties)
             return
 
         # preset_mode == PRESET_MODE_MANUAL
@@ -276,4 +276,4 @@ class EchonetLiteFan(EchonetLiteEntity, FanEntity):
                 translation_key="epc_not_writable",
                 translation_placeholders={"epc_list": f"0x{EPC_OPERATION_STATUS:02X}"},
             )
-        await self._async_send_prop(self.entity_description.op_status, True)
+        self._send_prop(self.entity_description.op_status, True)

--- a/custom_components/echonet_lite/light.py
+++ b/custom_components/echonet_lite/light.py
@@ -227,20 +227,18 @@ class EchonetLiteLight(EchonetLiteEntity, LightEntity):
         """Turn the light on, applying any brightness/color/effect overrides."""
         # Always send the power-on command first so subsequent setters apply
         # to an already-powered device.
-        await self._async_send_prop(self.entity_description.op_status, True)
+        self._send_prop(self.entity_description.op_status, True)
         if (
             self._supports_brightness
             and (brightness := kwargs.get(ATTR_BRIGHTNESS)) is not None
         ):
             pct = _brightness_ha_to_pct(int(brightness))
-            await self._async_send_prop(
-                self.entity_description.brightness_prop, float(pct)
-            )
+            self._send_prop(self.entity_description.brightness_prop, float(pct))
         if (
             self._supports_color_temp
             and (kelvin := kwargs.get(ATTR_COLOR_TEMP_KELVIN)) is not None
         ):
-            await self._async_send_prop(
+            self._send_prop(
                 self.entity_description.color_prop,  # type: ignore[arg-type]
                 _closest_kelvin_key(int(kelvin)),
             )
@@ -249,7 +247,7 @@ class EchonetLiteLight(EchonetLiteEntity, LightEntity):
             and (effect := kwargs.get(ATTR_EFFECT)) is not None
             and effect in self.entity_description.mode_prop.options  # type: ignore[union-attr]
         ):
-            await self._async_send_prop(
+            self._send_prop(
                 self.entity_description.mode_prop,  # type: ignore[arg-type]
                 effect,
             )
@@ -257,4 +255,4 @@ class EchonetLiteLight(EchonetLiteEntity, LightEntity):
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off via the operation status codec."""
-        await self._async_send_prop(self.entity_description.op_status, False)
+        self._send_prop(self.entity_description.op_status, False)

--- a/custom_components/echonet_lite/lock.py
+++ b/custom_components/echonet_lite/lock.py
@@ -130,9 +130,9 @@ class EchonetLiteLock(EchonetLiteEntity, LockEntity):
         sub-lock typically engage it themselves via Auto-Lock or via the
         physical mechanism.
         """
-        await self._async_send_prop(self.entity_description.lock_prop, True)
+        self._send_prop(self.entity_description.lock_prop, True)
 
     @override
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the device by writing the primary lock EPC only."""
-        await self._async_send_prop(self.entity_description.lock_prop, False)
+        self._send_prop(self.entity_description.lock_prop, False)

--- a/custom_components/echonet_lite/number.py
+++ b/custom_components/echonet_lite/number.py
@@ -115,4 +115,4 @@ class EchonetLiteNumber(
     @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the value by sending an ECHONET Lite command."""
-        await self._async_send_prop(self.description.prop, value)
+        self._send_prop(self.description.prop, value)

--- a/custom_components/echonet_lite/runtime.py
+++ b/custom_components/echonet_lite/runtime.py
@@ -268,7 +268,7 @@ class RuntimeController:
 
     async def _run_initial_discovery(self) -> None:
         """Run the initial probe and start recurring discovery."""
-        if not await self.client.probe_initial_nodes():
+        if not self.client.probe_initial_nodes():
             _LOGGER.warning("Initial ECHONET Lite node discovery could not be sent")
             self._start_periodic_discovery()
             return
@@ -314,7 +314,7 @@ class RuntimeController:
             event = await self._event_queue.get()
             try:
                 if isinstance(event, HemsFrameEvent):
-                    await self.coordinator.async_process_frame_event(event)
+                    self.coordinator.process_frame_event(event)
                     self.issue_monitor.record_activity(event.received_at)
                 elif isinstance(event, HemsInstanceListEvent):
                     _LOGGER.debug(
@@ -375,7 +375,7 @@ class RuntimeController:
             if self._initial_discovery_complete.is_set():
                 self._start_periodic_discovery()
             else:
-                await self.client.probe_initial_nodes()
+                self.client.probe_initial_nodes()
             self.health.last_restart_at = time.monotonic()
             self.issue_monitor.clear_client_error()
             # Treat a successful restart as activity so the inactivity issue

--- a/custom_components/echonet_lite/select.py
+++ b/custom_components/echonet_lite/select.py
@@ -120,7 +120,7 @@ class EchonetLiteSelect(
     async def async_select_option(self, option: str) -> None:
         """Select the given option by sending the corresponding payload."""
         try:
-            await self._async_send_prop(self.description.prop, option)
+            self._send_prop(self.description.prop, option)
         except ValueError as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
@@ -218,14 +218,14 @@ class InstallationLocationCodeSelect(EchonetLiteEntity, SelectEntity):
             if new_llll == 0:
                 # "unset" selected — write 0x00; forcing NNN=0 avoids generating
                 # the prohibited 0x01-0x07 range (17-byte format indicators).
-                await self._async_send_property(EPC_INSTALLATION_LOCATION, b"\x00")
+                self._send_property(EPC_INSTALLATION_LOCATION, b"\x00")
                 return
             fields = _decode_location_fields(self._node)
             nnn = fields[1] if fields is not None else 0
             edt = InstallationLocationCodec().encode(
                 InstallationLocation.from_code(new_llll, nnn)
             )
-            await self._async_send_property(EPC_INSTALLATION_LOCATION, edt)
+            self._send_property(EPC_INSTALLATION_LOCATION, edt)
 
 
 class InstallationLocationNumberSelect(EchonetLiteEntity, SelectEntity):
@@ -284,4 +284,4 @@ class InstallationLocationNumberSelect(EchonetLiteEntity, SelectEntity):
             edt = InstallationLocationCodec().encode(
                 InstallationLocation.from_code(llll, new_nnn)
             )
-            await self._async_send_property(EPC_INSTALLATION_LOCATION, edt)
+            self._send_property(EPC_INSTALLATION_LOCATION, edt)

--- a/custom_components/echonet_lite/switch.py
+++ b/custom_components/echonet_lite/switch.py
@@ -78,9 +78,9 @@ class EchonetLiteSwitch(
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Send the On command via the pyhems runtime client."""
-        await self._async_send_prop(self.description.prop, True)
+        self._send_prop(self.description.prop, True)
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Send the Off command via the pyhems runtime client."""
-        await self._async_send_prop(self.description.prop, False)
+        self._send_prop(self.description.prop, False)

--- a/custom_components/echonet_lite/water_heater.py
+++ b/custom_components/echonet_lite/water_heater.py
@@ -190,7 +190,7 @@ class EchonetLiteWaterHeater(EchonetLiteEntity, WaterHeaterEntity):
                 translation_key="epc_not_writable",
                 translation_placeholders={"epc_list": f"0x{EPC_OPERATION_STATUS:02X}"},
             )
-        await self._async_send_prop(self.entity_description.op_status, True)
+        self._send_prop(self.entity_description.op_status, True)
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -201,7 +201,7 @@ class EchonetLiteWaterHeater(EchonetLiteEntity, WaterHeaterEntity):
                 translation_key="epc_not_writable",
                 translation_placeholders={"epc_list": f"0x{EPC_OPERATION_STATUS:02X}"},
             )
-        await self._async_send_prop(self.entity_description.op_status, False)
+        self._send_prop(self.entity_description.op_status, False)
 
     @override
     async def async_set_operation_mode(self, operation_mode: str) -> None:
@@ -224,7 +224,7 @@ class EchonetLiteWaterHeater(EchonetLiteEntity, WaterHeaterEntity):
         properties = [self.entity_description.op_mode.make_property(operation_mode)]
         if EPC_OPERATION_STATUS in self._node.set_epcs:
             properties.append(self.entity_description.op_status.make_property(True))
-        await self._async_send_properties(properties)
+        self._send_properties(properties)
 
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -244,4 +244,4 @@ class EchonetLiteWaterHeater(EchonetLiteEntity, WaterHeaterEntity):
             )
         temperature = float(kwargs[ATTR_TEMPERATURE])
         clamped = min(max(temperature, self._attr_min_temp), self._attr_max_temp)
-        await self._async_send_prop(self.entity_description.target_temp_prop, clamped)
+        self._send_prop(self.entity_description.target_temp_prop, clamped)


### PR DESCRIPTION
## Summary

Remove unnecessary coroutines from non-waiting runtime and entity property-send paths while keeping Home Assistant public action methods asynchronous.

## Changes

- Synchronize the runtime/coordinator bridge for frame processing and non-waiting discovery calls.
- Rename and synchronize `_send_property`, `_send_properties`, and `_send_prop`.
- Update all entity platform call sites to use synchronous helper calls.
- Keep public Home Assistant action methods asynchronous.
- Sync the custom integration with the core integration changes.

## Dependency

- Depends on [pyhems#54](https://github.com/sayurin/pyhems/pull/54).

## Validation

- Core integration tests: 354 passed
- Core integration coverage: 98%
- Core prek checks passed